### PR TITLE
test: integration test coverage for all routes

### DIFF
--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -1,0 +1,165 @@
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def login(test_client: AsyncClient, user) -> dict:
+    resp = await test_client.post("/v1/auth/login", json={"username": user.username, "password": "testpass123"})
+    return dict(resp.cookies)
+
+
+async def test_stats_as_admin(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get("/v1/admin/stats", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "song_count" in body
+    assert "user_count" in body
+    assert "disk_bytes" in body
+    assert "recent_jobs" in body
+
+
+async def test_stats_as_regular_user_forbidden(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/admin/stats", cookies=cookies)
+    assert resp.status_code == 403
+
+
+async def test_errors_as_admin(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get("/v1/admin/errors", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total" in body
+    assert "errors" in body
+    assert isinstance(body["errors"], list)
+
+
+async def test_errors_as_regular_user_forbidden(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/admin/errors", cookies=cookies)
+    assert resp.status_code == 403
+
+
+async def test_update_user_as_admin(test_client: AsyncClient, admin_user, regular_user):
+    cookies = await login(test_client, admin_user)
+
+    resp = await test_client.patch(
+        f"/v1/admin/users/{regular_user.id}",
+        json={"is_active": False},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["is_active"] is False
+
+    restore = await test_client.patch(
+        f"/v1/admin/users/{regular_user.id}",
+        json={"is_active": True},
+        cookies=cookies,
+    )
+    assert restore.status_code == 200
+    assert restore.json()["is_active"] is True
+
+
+async def test_list_users_as_admin(test_client: AsyncClient, admin_user, regular_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get("/v1/admin/users", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) >= 2
+
+
+async def test_list_users_as_regular_user_forbidden(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/admin/users", cookies=cookies)
+    assert resp.status_code == 403
+
+
+async def test_update_user_not_found(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.patch(
+        "/v1/admin/users/00000000-0000-0000-0000-000000000000",
+        json={"is_active": True},
+        cookies=cookies,
+    )
+    assert resp.status_code == 404
+
+
+async def test_update_user_role_as_admin(test_client: AsyncClient, admin_user, regular_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.patch(
+        f"/v1/admin/users/{regular_user.id}",
+        json={"role": "user"},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["role"] == "user"
+
+
+async def test_delete_user_as_admin(test_client: AsyncClient, admin_user):
+    import uuid
+    admin_login = await test_client.post("/v1/auth/login", json={"username": admin_user.username, "password": "testpass123"})
+    uname = f"todelete_{uuid.uuid4().hex[:6]}"
+    reg = await test_client.post(
+        "/v1/auth/register",
+        json={"username": uname, "email": f"{uname}@test.com", "password": "pass123"},
+        cookies=admin_login.cookies,
+    )
+    assert reg.status_code == 201
+    user_id = reg.json()["id"]
+
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.delete(f"/v1/admin/users/{user_id}", cookies=cookies)
+    assert resp.status_code == 204
+
+
+async def test_delete_user_not_found(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.delete("/v1/admin/users/00000000-0000-0000-0000-000000000000", cookies=cookies)
+    assert resp.status_code == 404
+
+
+async def test_delete_user_requires_admin(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.delete("/v1/admin/users/some-id", cookies=cookies)
+    assert resp.status_code == 403
+
+
+async def test_get_edit_jobs_as_admin(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get("/v1/admin/edit-jobs", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total" in body
+    assert "jobs" in body
+    assert isinstance(body["jobs"], list)
+
+
+async def test_get_edit_jobs_requires_admin(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/admin/edit-jobs", cookies=cookies)
+    assert resp.status_code == 403
+
+
+async def test_get_edit_jobs_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/admin/edit-jobs")
+    assert resp.status_code == 401
+
+
+async def test_stats_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/admin/stats")
+    assert resp.status_code == 401
+
+
+async def test_stats_has_extended_fields(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get("/v1/admin/stats", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "plays_by_day" in body
+    assert "top_songs" in body
+    assert "per_user" in body
+    assert "disk_total" in body
+    assert "disk_free" in body

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,0 +1,200 @@
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def test_root_is_public(test_client: AsyncClient):
+    assert (await test_client.get("/")).status_code == 200
+
+
+async def test_protected_route_requires_auth(test_client: AsyncClient):
+    assert (await test_client.get("/v1/properties/nonexistent-id")).status_code == 401
+
+
+async def test_login_success(test_client: AsyncClient, admin_user):
+    resp = await test_client.post("/v1/auth/login", json={"username": admin_user.username, "password": "testpass123"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["username"] == admin_user.username
+    assert body["role"] == "admin"
+    assert "access_token" in resp.cookies
+    assert "refresh_token" in resp.cookies
+
+
+async def test_login_wrong_password(test_client: AsyncClient, admin_user):
+    resp = await test_client.post("/v1/auth/login", json={"username": admin_user.username, "password": "wrong"})
+    assert resp.status_code == 401
+
+
+async def test_login_unknown_user(test_client: AsyncClient):
+    resp = await test_client.post("/v1/auth/login", json={"username": "nobody", "password": "pass"})
+    assert resp.status_code == 401
+
+
+async def test_me_returns_current_user(test_client: AsyncClient, regular_user):
+    login = await test_client.post("/v1/auth/login", json={"username": regular_user.username, "password": "testpass123"})
+    resp = await test_client.get("/v1/auth/me", cookies=login.cookies)
+    assert resp.status_code == 200
+    assert resp.json()["username"] == regular_user.username
+
+
+async def test_logout_clears_cookies(test_client: AsyncClient, admin_user):
+    login = await test_client.post("/v1/auth/login", json={"username": admin_user.username, "password": "testpass123"})
+    resp = await test_client.post("/v1/auth/logout", cookies=login.cookies)
+    assert resp.status_code == 200
+    assert resp.cookies.get("access_token", "") == ""
+
+
+async def test_register_requires_admin(test_client: AsyncClient, regular_user):
+    login = await test_client.post("/v1/auth/login", json={"username": regular_user.username, "password": "testpass123"})
+    resp = await test_client.post(
+        "/v1/auth/register",
+        json={"username": "newuser", "email": "new@test.com", "password": "pass123"},
+        cookies=login.cookies,
+    )
+    assert resp.status_code == 403
+
+
+async def test_register_as_admin(test_client: AsyncClient, admin_user):
+    import uuid
+    username = f"newuser_{uuid.uuid4().hex[:6]}"
+    login = await test_client.post("/v1/auth/login", json={"username": admin_user.username, "password": "testpass123"})
+    resp = await test_client.post(
+        "/v1/auth/register",
+        json={"username": username, "email": f"{username}@test.com", "password": "pass123"},
+        cookies=login.cookies,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["username"] == username
+
+
+async def test_token_refresh(test_client: AsyncClient, regular_user):
+    login = await test_client.post("/v1/auth/login", json={"username": regular_user.username, "password": "testpass123"})
+    resp = await test_client.post("/v1/auth/refresh", cookies=login.cookies)
+    assert resp.status_code == 200
+    assert "access_token" in resp.cookies
+
+
+async def test_refresh_without_cookie_fails(test_client: AsyncClient):
+    resp = await test_client.post("/v1/auth/refresh")
+    assert resp.status_code == 401
+
+
+async def test_me_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/auth/me")
+    assert resp.status_code == 401
+
+
+async def test_register_duplicate_username(test_client: AsyncClient, admin_user):
+    import uuid
+    login_resp = await test_client.post("/v1/auth/login", json={"username": admin_user.username, "password": "testpass123"})
+    # register a new user
+    unique = uuid.uuid4().hex[:8]
+    await test_client.post(
+        "/v1/auth/register",
+        json={"username": unique, "email": f"{unique}@test.com", "password": "pass"},
+        cookies=login_resp.cookies,
+    )
+    # try registering same username again
+    resp = await test_client.post(
+        "/v1/auth/register",
+        json={"username": unique, "email": f"other_{unique}@test.com", "password": "pass"},
+        cookies=login_resp.cookies,
+    )
+    assert resp.status_code == 409
+
+
+async def test_register_duplicate_email(test_client: AsyncClient, admin_user):
+    import uuid
+    login_resp = await test_client.post("/v1/auth/login", json={"username": admin_user.username, "password": "testpass123"})
+    unique = uuid.uuid4().hex[:8]
+    await test_client.post(
+        "/v1/auth/register",
+        json={"username": unique, "email": f"{unique}@test.com", "password": "pass"},
+        cookies=login_resp.cookies,
+    )
+    resp = await test_client.post(
+        "/v1/auth/register",
+        json={"username": f"other_{unique}", "email": f"{unique}@test.com", "password": "pass"},
+        cookies=login_resp.cookies,
+    )
+    assert resp.status_code == 409
+
+
+async def test_register_without_auth(test_client: AsyncClient):
+    resp = await test_client.post(
+        "/v1/auth/register",
+        json={"username": "anon", "email": "anon@test.com", "password": "pass"},
+    )
+    assert resp.status_code == 401
+
+
+async def test_change_password(test_client: AsyncClient, admin_user):
+    import uuid
+    # register a throwaway user to change password on
+    admin_login = await test_client.post("/v1/auth/login", json={"username": admin_user.username, "password": "testpass123"})
+    uname = f"pwchange_{uuid.uuid4().hex[:6]}"
+    await test_client.post(
+        "/v1/auth/register",
+        json={"username": uname, "email": f"{uname}@test.com", "password": "oldpass"},
+        cookies=admin_login.cookies,
+    )
+    user_login = await test_client.post("/v1/auth/login", json={"username": uname, "password": "oldpass"})
+    assert user_login.status_code == 200
+
+    resp = await test_client.patch(
+        "/v1/auth/password",
+        json={"current_password": "oldpass", "new_password": "newpass"},
+        cookies=user_login.cookies,
+    )
+    assert resp.status_code == 204
+
+    # old password should no longer work
+    old_login = await test_client.post("/v1/auth/login", json={"username": uname, "password": "oldpass"})
+    assert old_login.status_code == 401
+
+    # new password should work
+    new_login = await test_client.post("/v1/auth/login", json={"username": uname, "password": "newpass"})
+    assert new_login.status_code == 200
+
+
+async def test_change_password_wrong_current(test_client: AsyncClient, regular_user):
+    login_resp = await test_client.post("/v1/auth/login", json={"username": regular_user.username, "password": "testpass123"})
+    resp = await test_client.patch(
+        "/v1/auth/password",
+        json={"current_password": "wrongpassword", "new_password": "newpass"},
+        cookies=login_resp.cookies,
+    )
+    assert resp.status_code == 401
+
+
+async def test_change_password_requires_auth(test_client: AsyncClient):
+    resp = await test_client.patch(
+        "/v1/auth/password",
+        json={"current_password": "x", "new_password": "y"},
+    )
+    assert resp.status_code == 401
+
+
+async def test_disabled_user_cannot_login(test_client: AsyncClient, admin_user):
+    import uuid
+    admin_login = await test_client.post("/v1/auth/login", json={"username": admin_user.username, "password": "testpass123"})
+    uname = f"disabled_{uuid.uuid4().hex[:6]}"
+    reg = await test_client.post(
+        "/v1/auth/register",
+        json={"username": uname, "email": f"{uname}@test.com", "password": "pass123"},
+        cookies=admin_login.cookies,
+    )
+    assert reg.status_code == 201
+    user_id = reg.json()["id"]
+
+    # disable the user
+    await test_client.patch(
+        f"/v1/admin/users/{user_id}",
+        json={"is_active": False},
+        cookies=admin_login.cookies,
+    )
+
+    resp = await test_client.post("/v1/auth/login", json={"username": uname, "password": "pass123"})
+    assert resp.status_code == 403

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -1,0 +1,66 @@
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def login(test_client: AsyncClient, user) -> dict:
+    resp = await test_client.post("/v1/auth/login", json={"username": user.username, "password": "testpass123"})
+    return dict(resp.cookies)
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+async def test_download_post_requires_auth(test_client: AsyncClient):
+    resp = await test_client.post("/v1/download/", json={"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"})
+    assert resp.status_code == 401
+
+
+async def test_get_download_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/download/nonexistent-id")
+    assert resp.status_code == 401
+
+
+async def test_delete_download_requires_auth(test_client: AsyncClient):
+    resp = await test_client.delete("/v1/download/nonexistent-id")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /download/{id} — 404 for missing song
+# ---------------------------------------------------------------------------
+
+async def test_get_download_not_found(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/download/00000000-0000-0000-0000-000000000000", cookies=cookies)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /download/{id} — succeeds even when song doesn't exist (no-op)
+# ---------------------------------------------------------------------------
+
+async def test_delete_download_nonexistent_is_ok(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.delete("/v1/download/00000000-0000-0000-0000-000000000000", cookies=cookies)
+    # router does not raise on missing — just deletes nothing
+    assert resp.status_code in (200, 204)
+
+
+# ---------------------------------------------------------------------------
+# POST /download/ — cached-song path (url already in DB)
+# ---------------------------------------------------------------------------
+
+async def test_download_cached_returns_existing_song(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(
+        "/v1/download/",
+        json={"url": sample_song.url, "ignore_cache": False},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "song_ids" in body
+    assert sample_song.uuid in body["song_ids"]

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -1,0 +1,140 @@
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+MINIMAL_MP3 = (
+    b'ID3\x03\x00\x00\x00\x00\x00\x00'  # ID3v2 header, empty tags
+    + b'\xff\xfb\x90\x00' + b'\x00' * 413  # MP3 frame header + padding
+)
+
+
+async def login(test_client: AsyncClient, user) -> dict:
+    resp = await test_client.post("/v1/auth/login", json={"username": user.username, "password": "testpass123"})
+    return dict(resp.cookies)
+
+
+async def test_start_import_requires_auth(test_client: AsyncClient):
+    resp = await test_client.post("/v1/import", files={"file": ("song.mp3", MINIMAL_MP3, "audio/mpeg")})
+    assert resp.status_code == 401
+
+
+async def test_start_import_invalid_file_type(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(
+        "/v1/import",
+        files={"file": ("notes.txt", b"hello", "text/plain")},
+        cookies=cookies,
+    )
+    assert resp.status_code == 400
+
+
+async def test_start_import_valid_mp3(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(
+        "/v1/import",
+        files={"file": ("song.mp3", MINIMAL_MP3, "audio/mpeg")},
+        cookies=cookies,
+    )
+    assert resp.status_code == 202
+    body = resp.json()
+    assert "job_id" in body
+    assert body["status"] in ("pending", "processing")
+
+
+async def test_list_imports_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/import")
+    assert resp.status_code == 401
+
+
+async def test_list_imports_empty(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get("/v1/import", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total" in body
+    assert "jobs" in body
+    assert isinstance(body["jobs"], list)
+
+
+async def test_list_imports_after_upload(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    post = await test_client.post(
+        "/v1/import",
+        files={"file": ("track.mp3", MINIMAL_MP3, "audio/mpeg")},
+        cookies=cookies,
+    )
+    assert post.status_code == 202
+    job_id = post.json()["job_id"]
+
+    resp = await test_client.get("/v1/import", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total" in body
+    assert "jobs" in body
+    assert any(j["job_id"] == job_id for j in body["jobs"])
+
+
+async def test_get_import_job_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/import/some-job-id")
+    assert resp.status_code == 401
+
+
+async def test_get_import_job_not_found(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/import/nonexistent-job-id", cookies=cookies)
+    assert resp.status_code == 404
+
+
+async def test_get_import_job_found(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    post = await test_client.post(
+        "/v1/import",
+        files={"file": ("album.mp3", MINIMAL_MP3, "audio/mpeg")},
+        cookies=cookies,
+    )
+    assert post.status_code == 202
+    job_id = post.json()["job_id"]
+
+    resp = await test_client.get(f"/v1/import/{job_id}", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["job_id"] == job_id
+    assert "status" in body
+
+
+async def test_start_import_valid_m4a(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(
+        "/v1/import",
+        files={"file": ("song.m4a", MINIMAL_MP3, "audio/mp4")},
+        cookies=cookies,
+    )
+    assert resp.status_code == 202
+    body = resp.json()
+    assert "job_id" in body
+
+
+async def test_list_imports_pagination(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/import?limit=1&offset=0", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total" in body
+    assert "jobs" in body
+    assert len(body["jobs"]) <= 1
+
+
+async def test_import_job_not_visible_to_other_user(test_client: AsyncClient, regular_user, admin_user):
+    reg_cookies = await login(test_client, regular_user)
+    post = await test_client.post(
+        "/v1/import",
+        files={"file": ("private.mp3", MINIMAL_MP3, "audio/mpeg")},
+        cookies=reg_cookies,
+    )
+    assert post.status_code == 202
+    job_id = post.json()["job_id"]
+
+    adm_cookies = await login(test_client, admin_user)
+    resp = await test_client.get(f"/v1/import/{job_id}", cookies=adm_cookies)
+    assert resp.status_code == 404

--- a/tests/integration/test_library.py
+++ b/tests/integration/test_library.py
@@ -1,0 +1,120 @@
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def login(test_client: AsyncClient, user) -> dict:
+    resp = await test_client.post("/v1/auth/login", json={"username": user.username, "password": "testpass123"})
+    return dict(resp.cookies)
+
+
+async def test_library_empty_on_start(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/library", cookies=cookies)
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_add_to_library(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["song_id"] == sample_song.uuid
+    assert body["last_position"] == 0.0
+    assert body["last_played_at"] is None
+
+
+async def test_add_to_library_idempotent(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    resp = await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    assert resp.status_code == 201
+
+
+async def test_add_nonexistent_song_returns_404(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post("/v1/library/does-not-exist", cookies=cookies)
+    assert resp.status_code == 404
+
+
+async def test_library_contains_added_song(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    resp = await test_client.get("/v1/library", cookies=cookies)
+    assert resp.status_code == 200
+    assert any(e["song_id"] == sample_song.uuid for e in resp.json())
+
+
+async def test_remove_from_library(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    resp = await test_client.delete(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    assert resp.status_code == 204
+    resp = await test_client.get("/v1/library", cookies=cookies)
+    assert not any(e["song_id"] == sample_song.uuid for e in resp.json())
+
+
+async def test_remove_nonexistent_returns_404(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.delete("/v1/library/does-not-exist", cookies=cookies)
+    assert resp.status_code == 404
+
+
+async def test_update_position(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    resp = await test_client.patch(f"/v1/library/{sample_song.uuid}/position", json={"position": 42.5}, cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["last_position"] == 42.5
+    assert body["last_played_at"] is not None
+
+
+async def test_update_position_not_in_library_returns_404(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.patch("/v1/library/00000000-0000-0000-0000-000000000000/position", json={"position": 10.0}, cookies=cookies)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Auth required
+# ---------------------------------------------------------------------------
+
+async def test_get_library_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/library")
+    assert resp.status_code == 401
+
+
+async def test_add_to_library_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.post(f"/v1/library/{sample_song.uuid}")
+    assert resp.status_code == 401
+
+
+async def test_remove_from_library_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.delete(f"/v1/library/{sample_song.uuid}")
+    assert resp.status_code == 401
+
+
+async def test_update_position_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.patch(f"/v1/library/{sample_song.uuid}/position", json={"position": 0.0})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /publish
+# ---------------------------------------------------------------------------
+
+async def test_publish_requires_auth(test_client: AsyncClient):
+    resp = await test_client.post("/v1/library/publish")
+    assert resp.status_code == 401
+
+
+async def test_publish_returns_count(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post("/v1/library/publish", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "published" in body
+    assert isinstance(body["published"], int)

--- a/tests/integration/test_player.py
+++ b/tests/integration/test_player.py
@@ -1,0 +1,81 @@
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def login(test_client: AsyncClient, user) -> dict:
+    resp = await test_client.post("/v1/auth/login", json={"username": user.username, "password": "testpass123"})
+    return dict(resp.cookies)
+
+
+async def test_get_player_state(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "shuffle" in body
+    assert "repeat" in body
+    assert "queue" in body
+    assert "queue_index" in body
+
+
+async def test_put_player_state(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.put(
+        "/v1/player/state",
+        json={"shuffle": True, "repeat": "all", "queue": [], "queue_index": -1},
+        cookies=cookies,
+    )
+    assert resp.status_code in (200, 204)
+
+
+async def test_player_state_persists(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    await test_client.put(
+        "/v1/player/state",
+        json={"shuffle": True, "repeat": "all", "queue": [], "queue_index": -1},
+        cookies=cookies,
+    )
+    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["shuffle"] is True
+    assert body["repeat"] == "all"
+
+
+async def test_get_player_state_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/player/state")
+    assert resp.status_code == 401
+
+
+async def test_put_player_state_requires_auth(test_client: AsyncClient):
+    resp = await test_client.put(
+        "/v1/player/state",
+        json={"shuffle": False, "repeat": "off", "queue": [], "queue_index": -1},
+    )
+    assert resp.status_code == 401
+
+
+async def test_put_player_state_invalid_repeat(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.put(
+        "/v1/player/state",
+        json={"shuffle": False, "repeat": "invalid_value", "queue": [], "queue_index": -1},
+        cookies=cookies,
+    )
+    assert resp.status_code == 422
+
+
+async def test_put_player_state_with_queue(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.put(
+        "/v1/player/state",
+        json={"shuffle": False, "repeat": "one", "queue": [sample_song.uuid], "queue_index": 0},
+        cookies=cookies,
+    )
+    assert resp.status_code in (200, 204)
+    if resp.status_code == 200:
+        body = resp.json()
+        assert body["queue"] == [sample_song.uuid]
+        assert body["queue_index"] == 0

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -1,0 +1,116 @@
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+_VALID_PROPERTIES = {
+    "trackName": "Test",
+    "artistName": "Artist",
+    "collectionName": "Album",
+    "artworkUrl100": "https://example.com/art.jpg",
+    "primaryGenreName": "Pop",
+    "trackNumber": 1,
+    "trackCount": 10,
+    "collectionId": "12345",
+    "discNumber": 1,
+    "discCount": 1,
+    "releaseDate": "2020-01-01",
+    "releaseDateKey": "2020-01-01",
+}
+
+
+async def login(test_client: AsyncClient, user) -> dict:
+    resp = await test_client.post("/v1/auth/login", json={"username": user.username, "password": "testpass123"})
+    return dict(resp.cookies)
+
+
+async def test_search_properties(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/properties/", params={"query": "test"}, cookies=cookies)
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+async def test_put_properties(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.put(
+        "/v1/properties/",
+        json={"song_id": sample_song.uuid, "properties": _VALID_PROPERTIES},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["song_id"] == sample_song.uuid
+
+
+# ---------------------------------------------------------------------------
+# Auth required
+# ---------------------------------------------------------------------------
+
+async def test_search_properties_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/properties/", params={"query": "test"})
+    assert resp.status_code == 401
+
+
+async def test_put_properties_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.put(
+        "/v1/properties/",
+        json={"song_id": sample_song.uuid, "properties": _VALID_PROPERTIES},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /{id}
+# ---------------------------------------------------------------------------
+
+async def test_get_properties_by_id_not_found(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/properties/00000000-0000-0000-0000-000000000000", cookies=cookies)
+    assert resp.status_code == 404
+
+
+async def test_get_properties_by_id_no_properties(test_client: AsyncClient, regular_user, sample_song):
+    # sample_song has no properties set initially — after put_properties test above it does,
+    # so this verifies the song exists but we test a fresh song with no props
+    cookies = await login(test_client, regular_user)
+    # Use sample_song after properties have been set; properties exist now so expect 200
+    resp = await test_client.get(f"/v1/properties/{sample_song.uuid}", cookies=cookies)
+    # Could be 200 (if properties were set by earlier test) or 404 (if not set)
+    assert resp.status_code in (200, 404)
+
+
+async def test_get_properties_by_id_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.get(f"/v1/properties/{sample_song.uuid}")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PUT / — 404 for missing song
+# ---------------------------------------------------------------------------
+
+async def test_put_properties_song_not_found(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.put(
+        "/v1/properties/",
+        json={"song_id": "00000000-0000-0000-0000-000000000000", "properties": _VALID_PROPERTIES},
+        cookies=cookies,
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /itunes
+# ---------------------------------------------------------------------------
+
+async def test_get_itunes_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/properties/itunes", params={"query": "test"})
+    assert resp.status_code == 401
+
+
+async def test_get_itunes_returns_list(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/properties/itunes", params={"query": "test song"}, cookies=cookies)
+    # itunes API may or may not be reachable in test env; accept 200 or 5xx
+    assert resp.status_code in (200, 500, 502, 503)
+    if resp.status_code == 200:
+        assert isinstance(resp.json(), list)

--- a/tests/integration/test_share.py
+++ b/tests/integration/test_share.py
@@ -1,0 +1,66 @@
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def login(test_client: AsyncClient, user) -> dict:
+    resp = await test_client.post("/v1/auth/login", json={"username": user.username, "password": "testpass123"})
+    return dict(resp.cookies)
+
+
+async def test_create_share_link(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(f"/v1/share/songs/{sample_song.uuid}", cookies=cookies)
+    assert resp.status_code in (200, 201)
+    body = resp.json()
+    assert "token" in body
+
+
+async def test_share_info_no_auth(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    create_resp = await test_client.post(f"/v1/share/songs/{sample_song.uuid}", cookies=cookies)
+    token = create_resp.json()["token"]
+
+    resp = await test_client.get(f"/v1/share/{token}/info")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "song_id" in body
+    assert "token" in body
+
+
+async def test_create_share_link_nonexistent_song(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post("/v1/share/songs/nonexistent", cookies=cookies)
+    assert resp.status_code == 404
+
+
+async def test_share_info_bad_token(test_client: AsyncClient):
+    resp = await test_client.get("/v1/share/badtoken/info")
+    assert resp.status_code == 404
+
+
+async def test_create_share_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.post(f"/v1/share/songs/{sample_song.uuid}")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /{token}/download
+# ---------------------------------------------------------------------------
+
+async def test_download_shared_bad_token(test_client: AsyncClient):
+    resp = await test_client.get("/v1/share/badtoken/download")
+    assert resp.status_code == 404
+
+
+async def test_download_shared_no_file(test_client: AsyncClient, regular_user, sample_song):
+    # sample_song.file_path is /tmp/test-song.mp3 which doesn't actually exist on disk
+    cookies = await login(test_client, regular_user)
+    create_resp = await test_client.post(f"/v1/share/songs/{sample_song.uuid}", cookies=cookies)
+    assert create_resp.status_code in (200, 201)
+    token = create_resp.json()["token"]
+
+    resp = await test_client.get(f"/v1/share/{token}/download")
+    # file doesn't exist on disk — expect 404
+    assert resp.status_code == 404

--- a/tests/integration/test_songs.py
+++ b/tests/integration/test_songs.py
@@ -1,0 +1,115 @@
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def login(test_client: AsyncClient, user) -> dict:
+    resp = await test_client.post("/v1/auth/login", json={"username": user.username, "password": "testpass123"})
+    return dict(resp.cookies)
+
+
+async def test_list_songs_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/songs/")
+    assert resp.status_code == 401
+
+
+async def test_list_songs(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/songs/", cookies=cookies)
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+async def test_library_songs_contains_uuid(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    resp = await test_client.get("/v1/songs/library", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert any(e["uuid"] == sample_song.uuid for e in body)
+
+
+async def test_record_play(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(f"/v1/songs/{sample_song.uuid}/play", cookies=cookies)
+    assert resp.status_code in (200, 204)
+
+
+async def test_explore_week(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/songs/explore?window=week", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "most_played" in body
+    assert "recently_added" in body
+
+
+async def test_explore_day(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/songs/explore?window=day", cookies=cookies)
+    assert resp.status_code == 200
+
+
+async def test_explore_all(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get("/v1/songs/explore?window=all", cookies=cookies)
+    assert resp.status_code == 200
+
+
+async def test_explore_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/songs/explore?window=week")
+    assert resp.status_code == 401
+
+
+async def test_record_play_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.post(f"/v1/songs/{sample_song.uuid}/play")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /{id}/artwork
+# ---------------------------------------------------------------------------
+
+async def test_get_artwork_not_found_song(test_client: AsyncClient):
+    resp = await test_client.get("/v1/songs/00000000-0000-0000-0000-000000000000/artwork")
+    assert resp.status_code == 404
+
+
+async def test_get_artwork_no_cached_artwork(test_client: AsyncClient, sample_song):
+    # sample_song has no artwork cached
+    resp = await test_client.get(f"/v1/songs/{sample_song.uuid}/artwork")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /{id}/artwork
+# ---------------------------------------------------------------------------
+
+async def test_upload_artwork_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.post(
+        f"/v1/songs/{sample_song.uuid}/artwork",
+        files={"file": ("art.jpg", b"\xff\xd8\xff\xe0" + b"\x00" * 100, "image/jpeg")},
+    )
+    assert resp.status_code == 401
+
+
+async def test_upload_artwork_song_not_found(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(
+        "/v1/songs/00000000-0000-0000-0000-000000000000/artwork",
+        files={"file": ("art.jpg", b"\xff\xd8\xff\xe0" + b"\x00" * 100, "image/jpeg")},
+        cookies=cookies,
+    )
+    assert resp.status_code == 404
+
+
+async def test_upload_artwork_invalid_file(test_client: AsyncClient, regular_user, sample_song):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(
+        f"/v1/songs/{sample_song.uuid}/artwork",
+        files={"file": ("art.txt", b"not an image", "text/plain")},
+        cookies=cookies,
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- New `test_downloads.py` — auth guards, 404, no-op DELETE, cache-hit POST
- `test_auth.py` — PATCH /password flow, wrong password, no-auth; duplicate user (409); disabled user (403); refresh without cookie (401); me requires auth
- `test_admin.py` — GET /edit-jobs, DELETE /users/{id}, PATCH /users/{id} 404, stats fields, errors shape
- `test_library.py` — POST /library/publish; auth-required checks for all endpoints
- `test_properties.py` — GET /itunes; GET /{id} 404 and no-auth; PUT / 404; auth-required for search and PUT
- `test_share.py` — GET /{token}/download bad-token + missing-file 404; auth required for create
- `test_player.py` — auth-required for GET and PUT; invalid repeat value 422; queue persistence
- `test_imports.py` — fixed ImportJobsPage shape; m4a upload; pagination; cross-user isolation

## Test plan
- [ ] `ENV=test pytest tests/integration/ -x`