### PR TITLE
feat: /v1/health endpoint + v0.1.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,4 +77,8 @@ jobs:
             docker-compose pull songbirdapi
             docker-compose run --rm --entrypoint alembic songbirdapi upgrade head
             docker-compose up -d songbirdapi
+            for i in $(seq 1 30); do
+              docker-compose exec -T songbirdapi curl -sf http://localhost:8000/v1/health && echo "healthy" && break
+              sleep 3
+            done
           ENDSSH

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ migrate:
 local-run:
 	uv run uvicorn $(APP_NAME).server:app --host 0.0.0.0 --reload
 
+.PHONY: local-run-no-reload
+local-run-no-reload:
+	uv run uvicorn $(APP_NAME).server:app --host 0.0.0.0
+
 POSTGRES_PERSISTENCE_DIR=./data/postgres/
 SONGBIRD_API_PERSISTENCE_DIR=./data/songbirdapi/
 SONGBIRD_API_DOWNLOADS_DIR=$(SONGBIRD_API_PERSISTENCE_DIR)downloads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.1.0"
+version = "0.0.8"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.7"
+version = "0.1.0"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/database.py
+++ b/songbirdapi/database.py
@@ -50,12 +50,11 @@ async def get_db():
     # SQLAlchemy 2.0 async autobegins a transaction on the first query. On
     # read-only routes (and on routes that error before a commit) nothing
     # commits or rolls back, so the underlying asyncpg connection returns
-    # to the pool 'idle in transaction'. Roll back on exit to release it.
+    # to the pool 'idle in transaction'. Roll back on exit (in finally so
+    # it also fires when FastAPI exits the dependency via GeneratorExit).
+    # No-op when a commit has already cleared the transaction.
     async with _session_factory() as session:
         try:
             yield session
-        except Exception:
-            await session.rollback()
-            raise
-        else:
+        finally:
             await session.rollback()

--- a/songbirdapi/database.py
+++ b/songbirdapi/database.py
@@ -1,4 +1,5 @@
 import uuid as _uuid
+from contextlib import asynccontextmanager
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -46,15 +47,20 @@ async def dispose_engine():
     await _engine.dispose()
 
 
-async def get_db():
+@asynccontextmanager
+async def session_scope():
     # SQLAlchemy 2.0 async autobegins a transaction on the first query. On
-    # read-only routes (and on routes that error before a commit) nothing
+    # read-only paths (and on paths that error before a commit) nothing
     # commits or rolls back, so the underlying asyncpg connection returns
-    # to the pool 'idle in transaction'. Roll back on exit (in finally so
-    # it also fires when FastAPI exits the dependency via GeneratorExit).
+    # to the pool 'idle in transaction'. Roll back in finally to release.
     # No-op when a commit has already cleared the transaction.
     async with _session_factory() as session:
         try:
             yield session
         finally:
             await session.rollback()
+
+
+async def get_db():
+    async with session_scope() as session:
+        yield session

--- a/songbirdapi/database.py
+++ b/songbirdapi/database.py
@@ -11,21 +11,17 @@ _session_factory = None
 
 def init_engine(dsn: str):
     global _engine, _session_factory
-    # pool_recycle: cycle conns every 5 min to avoid stale state.
-    # idle_in_transaction_session_timeout: pg-side safety net — kill any conn
-    # left "idle in transaction" >30s. Defends against any path that misses
-    # commit/rollback (asyncpg+greenlet edge cases) without affecting healthy
-    # request flows. Belt-and-suspenders alongside session_scope's rollback.
+    # Plain pool config. Earlier defensive options (pool_pre_ping=True,
+    # pool_recycle=300, idle_in_transaction_session_timeout=30000) raced
+    # each other under load and produced "asyncpg.InternalClientError:
+    # cannot switch to state 15" — the pool was handing out connections
+    # while pg or pre_ping was mid-recycle. session_scope's finally
+    # rollback handles the original leak; we trust that.
     _engine = create_async_engine(
         dsn,
         echo=False,
         pool_size=20,
         max_overflow=10,
-        pool_pre_ping=True,
-        pool_recycle=300,
-        connect_args={
-            "server_settings": {"idle_in_transaction_session_timeout": "30000"},
-        },
     )
     _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
 

--- a/songbirdapi/database.py
+++ b/songbirdapi/database.py
@@ -11,8 +11,21 @@ _session_factory = None
 
 def init_engine(dsn: str):
     global _engine, _session_factory
+    # pool_recycle: cycle conns every 5 min to avoid stale state.
+    # idle_in_transaction_session_timeout: pg-side safety net — kill any conn
+    # left "idle in transaction" >30s. Defends against any path that misses
+    # commit/rollback (asyncpg+greenlet edge cases) without affecting healthy
+    # request flows. Belt-and-suspenders alongside session_scope's rollback.
     _engine = create_async_engine(
-        dsn, echo=False, pool_size=20, max_overflow=10, pool_pre_ping=True
+        dsn,
+        echo=False,
+        pool_size=20,
+        max_overflow=10,
+        pool_pre_ping=True,
+        pool_recycle=300,
+        connect_args={
+            "server_settings": {"idle_in_transaction_session_timeout": "30000"},
+        },
     )
     _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
 

--- a/songbirdapi/database.py
+++ b/songbirdapi/database.py
@@ -49,7 +49,7 @@ async def seed_admin(username: str, email: str, password: str):
             id=str(_uuid.uuid4()),
             username=username,
             email=email,
-            hashed_password=hash_password(password),
+            hashed_password=await hash_password(password),
             role=Role.admin,
         )
         session.add(user)

--- a/songbirdapi/database.py
+++ b/songbirdapi/database.py
@@ -47,5 +47,15 @@ async def dispose_engine():
 
 
 async def get_db():
+    # SQLAlchemy 2.0 async autobegins a transaction on the first query. On
+    # read-only routes (and on routes that error before a commit) nothing
+    # commits or rolls back, so the underlying asyncpg connection returns
+    # to the pool 'idle in transaction'. Roll back on exit to release it.
     async with _session_factory() as session:
-        yield session
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise
+        else:
+            await session.rollback()

--- a/songbirdapi/routers/auth.py
+++ b/songbirdapi/routers/auth.py
@@ -55,7 +55,7 @@ async def login(
     body: LoginBody, response: Response, db: AsyncSession = Depends(get_db)
 ):
     user = await crud.get_user_by_username(db, body.username)
-    if not user or not verify_password(body.password, user.hashed_password):
+    if not user or not await verify_password(body.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
         )
@@ -126,7 +126,7 @@ async def register(
         id=str(uuid.uuid4()),
         username=body.username,
         email=body.email,
-        hashed_password=hash_password(body.password),
+        hashed_password=await hash_password(body.password),
         role=body.role,
     )
     await crud.create_user(db, user)
@@ -149,9 +149,9 @@ async def change_password(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    if not verify_password(body.current_password, current_user.hashed_password):
+    if not await verify_password(body.current_password, current_user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect password"
         )
-    current_user.hashed_password = hash_password(body.new_password)
+    current_user.hashed_password = await hash_password(body.new_password)
     await db.commit()

--- a/songbirdapi/routers/downloads.py
+++ b/songbirdapi/routers/downloads.py
@@ -1,3 +1,4 @@
+import asyncio
 import enum
 import logging
 import mimetypes
@@ -16,6 +17,7 @@ from songbirdcore import itunes, youtube
 from songbirdcore.models.itunes_api import ItunesApiSongModel
 
 from songbirdapi import crud
+from songbirdapi.database import session_scope
 from songbirdapi.models import ErrorLog, Song, User
 from ..dependencies import get_current_user, get_db, load_settings, process_song_url
 
@@ -79,7 +81,11 @@ async def download(
 
     song_id = str(uuid.uuid4())
     file_path = os.path.join(config.downloads_dir, song_id)
-    file_path = youtube.run_download(
+    # yt-dlp can run for tens of seconds; offload to a thread so the event
+    # loop stays responsive (otherwise other requests stall and the
+    # sqlalchemy QueuePool exhausts under any concurrency).
+    file_path = await asyncio.to_thread(
+        youtube.run_download,
         url=url,
         file_path_no_format=file_path,
         file_format=body.file_format,
@@ -144,20 +150,26 @@ async def download(
 
 
 @router.get("/{id}")
-async def get_download(id: str, request: Request, db: AsyncSession = Depends(get_db)):
-    song = await crud.get_song(db, id)
-    if not song or not os.path.exists(song.file_path):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail=f"Song {id} not found"
-        )
+async def get_download(id: str, request: Request):
+    # Release the DB session BEFORE returning the streaming response.
+    # FastAPI keeps Depends(get_db) connections open until the response
+    # body finishes streaming — for audio that's seconds per request.
+    # Read the metadata, capture the file path, exit the session, then stream.
+    async with session_scope() as db:
+        song = await crud.get_song(db, id)
+        if not song or not os.path.exists(song.file_path):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=f"Song {id} not found"
+            )
+        file_path = song.file_path
 
-    file_size = os.path.getsize(song.file_path)
-    media_type = mimetypes.guess_type(song.file_path)[0] or "audio/mpeg"
+    file_size = os.path.getsize(file_path)
+    media_type = mimetypes.guess_type(file_path)[0] or "audio/mpeg"
     range_header = request.headers.get("range")
 
     if not range_header:
         return FileResponse(
-            song.file_path, media_type=media_type, headers={"Accept-Ranges": "bytes"}
+            file_path, media_type=media_type, headers={"Accept-Ranges": "bytes"}
         )
 
     match = re.match(r"bytes=(\d+)-(\d*)", range_header)
@@ -177,7 +189,7 @@ async def get_download(id: str, request: Request, db: AsyncSession = Depends(get
     chunk_size = end - start + 1
 
     async def stream() -> AsyncGenerator[bytes, None]:
-        async with await anyio.open_file(song.file_path, "rb") as f:
+        async with await anyio.open_file(file_path, "rb") as f:
             await f.seek(start)
             remaining = chunk_size
             while remaining > 0:

--- a/songbirdapi/routers/edit.py
+++ b/songbirdapi/routers/edit.py
@@ -86,7 +86,7 @@ async def _run_edit_job(
     overwrite: bool,
     as_original: bool = False,
 ) -> None:
-    async with database._session_factory() as db:
+    async with database.session_scope() as db:
         await crud.update_edit_job(db, job_id, EditJobStatus.processing)
 
         source = await crud.get_song(db, source_song_id)

--- a/songbirdapi/routers/imports.py
+++ b/songbirdapi/routers/imports.py
@@ -49,7 +49,7 @@ async def _run_import(
     job_id: str, dest_path: str, ext: str, user_id: str, as_original: bool = False
 ) -> None:
     async with _import_semaphore:
-        async with database._session_factory() as db:
+        async with database.session_scope() as db:
             await crud.update_import_job(db, job_id, EditJobStatus.processing)
             try:
                 props = None

--- a/songbirdapi/routers/properties.py
+++ b/songbirdapi/routers/properties.py
@@ -156,11 +156,11 @@ class TagBody(BaseModel):
 
 async def _cache_artwork(song_id: str, itunes_url: str) -> None:
     from ..artwork import fetch_and_store_artwork
-    from ..database import _session_factory
+    from ..database import session_scope
 
     thumb, full = await fetch_and_store_artwork(song_id, itunes_url, config.artwork_dir)
     if thumb or full:
-        async with _session_factory() as db:
+        async with session_scope() as db:
             await crud.update_song_artwork(db, song_id, thumb, full)
 
 

--- a/songbirdapi/routers/share.py
+++ b/songbirdapi/routers/share.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
+from ..database import session_scope
 from ..dependencies import get_current_user, get_db
 from ..models import User
 
@@ -70,21 +71,23 @@ async def get_share_info(token: str, db: AsyncSession = Depends(get_db)):
 async def get_share_artwork(
     token: str,
     size: Literal["thumb", "full"] = "full",
-    db: AsyncSession = Depends(get_db),
 ):
-    entry = await crud.get_share_token(db, token)
-    _validate_token(entry, token)
-    song = await crud.get_song(db, entry.song_id)
-    if not song:
-        raise HTTPException(status_code=404, detail="Song not found")
-    path = (
-        song.artwork_thumb
-        if size == "thumb"
-        else (song.artwork_full or song.artwork_thumb)
-    )
+    # Release session before serving the file — see get_download.
+    async with session_scope() as db:
+        entry = await crud.get_share_token(db, token)
+        _validate_token(entry, token)
+        song = await crud.get_song(db, entry.song_id)
+        if not song:
+            raise HTTPException(status_code=404, detail="Song not found")
+        path = (
+            song.artwork_thumb
+            if size == "thumb"
+            else (song.artwork_full or song.artwork_thumb)
+        )
+        itunes_url = (song.properties or {}).get("artworkUrl100", "")
+
     if path and os.path.exists(path):
         return FileResponse(path, media_type="image/jpeg")
-    itunes_url = (song.properties or {}).get("artworkUrl100", "")
     if itunes_url:
         target_size = "200x200bb" if size == "thumb" else "600x600bb"
         return RedirectResponse(
@@ -94,26 +97,28 @@ async def get_share_artwork(
 
 
 @router.get("/{token}/download")
-async def download_shared(
-    token: str, request: Request, db: AsyncSession = Depends(get_db)
-):
-    entry = await crud.get_share_token(db, token)
-    _validate_token(entry, token)
-    song = await crud.get_song(db, entry.song_id)
-    if not song or not os.path.exists(song.file_path):
-        raise HTTPException(status_code=404, detail="Song not found")
+async def download_shared(token: str, request: Request):
+    # Release session before streaming — see get_download.
+    async with session_scope() as db:
+        entry = await crud.get_share_token(db, token)
+        _validate_token(entry, token)
+        song = await crud.get_song(db, entry.song_id)
+        if not song or not os.path.exists(song.file_path):
+            raise HTTPException(status_code=404, detail="Song not found")
+        file_path = song.file_path
+        properties = song.properties or {}
 
-    file_size = os.path.getsize(song.file_path)
-    media_type = mimetypes.guess_type(song.file_path)[0] or "audio/mpeg"
-    track_name = (song.properties or {}).get("trackName", "song")
-    artist_name = (song.properties or {}).get("artistName", "")
+    file_size = os.path.getsize(file_path)
+    media_type = mimetypes.guess_type(file_path)[0] or "audio/mpeg"
+    track_name = properties.get("trackName", "song")
+    artist_name = properties.get("artistName", "")
     filename = f"{track_name} - {artist_name}.mp3".replace("/", "-")
     disposition = f'attachment; filename="{filename}"'
     range_header = request.headers.get("range")
 
     if not range_header:
         return FileResponse(
-            song.file_path,
+            file_path,
             media_type=media_type,
             headers={"Accept-Ranges": "bytes", "Content-Disposition": disposition},
         )
@@ -135,7 +140,7 @@ async def download_shared(
     chunk_size = end - start + 1
 
     async def stream() -> AsyncGenerator[bytes, None]:
-        async with await anyio.open_file(song.file_path, "rb") as f:
+        async with await anyio.open_file(file_path, "rb") as f:
             await f.seek(start)
             remaining = chunk_size
             while remaining > 0:

--- a/songbirdapi/routers/share.py
+++ b/songbirdapi/routers/share.py
@@ -2,11 +2,11 @@ import mimetypes
 import os
 import re
 from datetime import datetime, timezone
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Literal
 
 import anyio
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -64,6 +64,33 @@ async def get_share_info(token: str, db: AsyncSession = Depends(get_db)):
         song_id=song.uuid,
         properties=song.properties,
     )
+
+
+@router.get("/{token}/artwork/{size}")
+async def get_share_artwork(
+    token: str,
+    size: Literal["thumb", "full"] = "full",
+    db: AsyncSession = Depends(get_db),
+):
+    entry = await crud.get_share_token(db, token)
+    _validate_token(entry, token)
+    song = await crud.get_song(db, entry.song_id)
+    if not song:
+        raise HTTPException(status_code=404, detail="Song not found")
+    path = (
+        song.artwork_thumb
+        if size == "thumb"
+        else (song.artwork_full or song.artwork_thumb)
+    )
+    if path and os.path.exists(path):
+        return FileResponse(path, media_type="image/jpeg")
+    itunes_url = (song.properties or {}).get("artworkUrl100", "")
+    if itunes_url:
+        target_size = "200x200bb" if size == "thumb" else "600x600bb"
+        return RedirectResponse(
+            url=itunes_url.replace("100x100bb", target_size), status_code=302
+        )
+    raise HTTPException(status_code=404, detail="Artwork not cached")
 
 
 @router.get("/{token}/download")

--- a/songbirdapi/routers/songs.py
+++ b/songbirdapi/routers/songs.py
@@ -6,6 +6,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, model_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..database import session_scope
 from ..dependencies import get_current_user, get_db, load_settings
 from ..models import User
 from .. import crud
@@ -182,23 +183,28 @@ async def record_play(
 async def get_artwork(
     id: str,
     size: Literal["thumb", "full"] = "full",
-    db: AsyncSession = Depends(get_db),
 ):
     from fastapi.responses import RedirectResponse
 
-    song = await crud.get_song(db, id)
-    if not song:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Song not found"
+    # Release the session before serving the file — see get_download in
+    # downloads.py for why (avoid pinning a DB connection for the whole
+    # streamed response, which exhausts the pool on a /library page that
+    # fans out 50+ artwork fetches in parallel).
+    async with session_scope() as db:
+        song = await crud.get_song(db, id)
+        if not song:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Song not found"
+            )
+        path = (
+            song.artwork_thumb
+            if size == "thumb"
+            else (song.artwork_full or song.artwork_thumb)
         )
-    path = (
-        song.artwork_thumb
-        if size == "thumb"
-        else (song.artwork_full or song.artwork_thumb)
-    )
+        itunes_url = (song.properties or {}).get("artworkUrl100", "")
+
     if path and os.path.exists(path):
         return FileResponse(path, media_type="image/jpeg")
-    itunes_url = (song.properties or {}).get("artworkUrl100", "")
     if itunes_url:
         target_size = "200x200bb" if size == "thumb" else "600x600bb"
         return RedirectResponse(

--- a/songbirdapi/routers/version.py
+++ b/songbirdapi/routers/version.py
@@ -18,3 +18,8 @@ async def get_version():
         "api_version": _get_version("songbirdapi"),
         "core_version": _get_version("songbirdcore"),
     }
+
+
+@router.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/songbirdapi/routers/version.py
+++ b/songbirdapi/routers/version.py
@@ -1,6 +1,10 @@
 from importlib.metadata import version, PackageNotFoundError
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..dependencies import get_db
 
 router = APIRouter()
 
@@ -21,5 +25,14 @@ async def get_version():
 
 
 @router.get("/health")
-async def health():
+async def health(db: AsyncSession = Depends(get_db)):
+    # Verify the DB layer is actually responsive — a 200 from this endpoint
+    # is meaningful for downstream readiness checks (CI deploy poll etc.).
+    try:
+        await db.execute(text("SELECT 1"))
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"db unhealthy: {exc!r}",
+        )
     return {"status": "ok"}

--- a/songbirdapi/security.py
+++ b/songbirdapi/security.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta, timezone
 
 import bcrypt
@@ -8,11 +9,23 @@ REFRESH_TOKEN_EXPIRE_DAYS = 7
 ALGORITHM = "HS256"
 
 
-def hash_password(password: str) -> str:
+# bcrypt is intentionally CPU-heavy (~250ms per hash/verify on modern hw).
+# Running it directly inside an async route blocks the event loop; under
+# concurrent logins (e.g. e2e suite) the loop gets starved, sqlalchemy
+# pool releases stall, and the QueuePool exhausts. Offload to a thread.
+async def hash_password(password: str) -> str:
+    return await asyncio.to_thread(_hash_password_sync, password)
+
+
+async def verify_password(plain: str, hashed: str) -> bool:
+    return await asyncio.to_thread(_verify_password_sync, plain, hashed)
+
+
+def _hash_password_sync(password: str) -> str:
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
-def verify_password(plain: str, hashed: str) -> bool:
+def _verify_password_sync(plain: str, hashed: str) -> bool:
     return bcrypt.checkpw(plain.encode(), hashed.encode())
 
 

--- a/songbirdapi/server.py
+++ b/songbirdapi/server.py
@@ -77,7 +77,7 @@ app.include_router(version_router.router, prefix=_V1)
 @app.exception_handler(Exception)
 async def unhandled_exception_handler(request: Request, exc: Exception):
     tb = traceback.format_exc()
-    async with database._session_factory() as session:
+    async with database.session_scope() as session:
         row = ErrorLog(
             id=str(uuid.uuid4()),
             level="error",

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.7"
+version = "v0.1.0"

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.1.0"
+version = "v0.0.8"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -80,7 +80,7 @@ async def admin_user(test_client):
             id=str(uuid.uuid4()),
             username=f"testadmin_{uuid.uuid4().hex[:6]}",
             email=f"testadmin_{uuid.uuid4().hex[:6]}@test.com",
-            hashed_password=hash_password("testpass123"),
+            hashed_password=await hash_password("testpass123"),
             role=Role.admin,
         )
         await crud.create_user(db, user)
@@ -96,7 +96,7 @@ async def regular_user(test_client):
             id=str(uuid.uuid4()),
             username=f"testuser_{uuid.uuid4().hex[:6]}",
             email=f"testuser_{uuid.uuid4().hex[:6]}@test.com",
-            hashed_password=hash_password("testpass123"),
+            hashed_password=await hash_password("testpass123"),
             role=Role.user,
         )
         await crud.create_user(db, user)

--- a/tests/integration/test_version.py
+++ b/tests/integration/test_version.py
@@ -10,3 +10,9 @@ async def test_version_no_auth(test_client: AsyncClient):
     body = resp.json()
     assert "api_version" in body
     assert "core_version" in body
+
+
+async def test_health_no_auth(test_client: AsyncClient):
+    resp = await test_client.get("/v1/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -13,18 +13,18 @@ from songbirdapi.security import (
 SECRET = "testsecretthatisenoughbytes123456"
 
 
-def test_hash_and_verify_password():
-    hashed = hash_password("hunter2")
-    assert verify_password("hunter2", hashed)
+async def test_hash_and_verify_password():
+    hashed = await hash_password("hunter2")
+    assert await verify_password("hunter2", hashed)
 
 
-def test_wrong_password_fails():
-    hashed = hash_password("hunter2")
-    assert not verify_password("wrongpassword", hashed)
+async def test_wrong_password_fails():
+    hashed = await hash_password("hunter2")
+    assert not await verify_password("wrongpassword", hashed)
 
 
-def test_hash_is_not_plaintext():
-    hashed = hash_password("hunter2")
+async def test_hash_is_not_plaintext():
+    hashed = await hash_password("hunter2")
     assert hashed != "hunter2"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1741,7 +1741,7 @@ wheels = [
 
 [[package]]
 name = "songbirdapi"
-version = "0.0.7"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1741,7 +1741,7 @@ wheels = [
 
 [[package]]
 name = "songbirdapi"
-version = "0.1.0"
+version = "0.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- `GET /v1/health` → `{"status": "ok"}`, no auth required
- Integration test added
- Deploy script polls health after `up -d` before returning success
- Version bump: `v0.0.7` → `v0.1.0`