### PR TITLE
fix(pool): release sessions during file IO + add pool integration tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,11 +74,22 @@ jobs:
             set -e
             docker system prune -f
             cd ~/songbird
+            # Pull explicitly + force-recreate. docker-compose up -d alone
+            # can skip recreating if it thinks the image hasn't changed
+            # (manifest-vs-cache races against a fresh push), which leaves
+            # the old container running. force-recreate guarantees we get
+            # the new image.
             docker-compose pull songbirdapi
             docker-compose run --rm --entrypoint alembic songbirdapi upgrade head
-            docker-compose up -d songbirdapi
+            docker-compose up -d --force-recreate songbirdapi
+            healthy=
             for i in $(seq 1 30); do
-              docker-compose exec -T songbirdapi curl -sf http://localhost:8000/v1/health && echo "healthy" && break
+              if docker-compose exec -T songbirdapi curl -sf http://localhost:8000/v1/health; then
+                healthy=1
+                echo "healthy"
+                break
+              fi
               sleep 3
             done
+            [ "$healthy" = "1" ] || (echo "deploy health-check FAILED" && docker-compose logs --tail=50 songbirdapi && exit 1)
           ENDSSH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.8"
+version = "0.0.9"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/database.py
+++ b/songbirdapi/database.py
@@ -11,17 +11,26 @@ _session_factory = None
 
 def init_engine(dsn: str):
     global _engine, _session_factory
-    # Plain pool config. Earlier defensive options (pool_pre_ping=True,
-    # pool_recycle=300, idle_in_transaction_session_timeout=30000) raced
-    # each other under load and produced "asyncpg.InternalClientError:
-    # cannot switch to state 15" — the pool was handing out connections
-    # while pg or pre_ping was mid-recycle. session_scope's finally
-    # rollback handles the original leak; we trust that.
+    # Pool defenses (carefully chosen to avoid the "cannot switch to state 15"
+    # race that bit us when all three were on AND pool_pre_ping was issuing
+    # SELECT 1 mid-recycle):
+    #
+    # - pool_pre_ping is OFF — it was the racer.
+    # - pool_recycle=600 — sqlalchemy itself ages out connections every 10 min.
+    #   Catches sessions that leaked because FastAPI didn't advance our
+    #   dependency generator on client disconnect (browser closes mid-request).
+    # - idle_in_transaction_session_timeout=120s on the pg side — pg terminates
+    #   any backend stuck "idle in transaction" longer than that, so leaks
+    #   self-heal even if sqlalchemy doesn't notice.
     _engine = create_async_engine(
         dsn,
         echo=False,
         pool_size=20,
         max_overflow=10,
+        pool_recycle=600,
+        connect_args={
+            "server_settings": {"idle_in_transaction_session_timeout": "120000"},
+        },
     )
     _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
 

--- a/songbirdapi/routers/downloads.py
+++ b/songbirdapi/routers/downloads.py
@@ -167,9 +167,17 @@ async def get_download(id: str, request: Request):
     media_type = mimetypes.guess_type(file_path)[0] or "audio/mpeg"
     range_header = request.headers.get("range")
 
+    # Cache-Control: no-store — the editor mounts 3 WaveSurfer/buffer
+    # consumers in parallel that all GET this same URL. Chromium's HTTP
+    # cache races on concurrent same-URL writes (ERR_CACHE_WRITE_FAILURE)
+    # and the lost fetches break WaveSurfer.load(), which leaves the
+    # editor's preview button permanently disabled. no-store skips the
+    # cache write entirely.
     if not range_header:
         return FileResponse(
-            file_path, media_type=media_type, headers={"Accept-Ranges": "bytes"}
+            file_path,
+            media_type=media_type,
+            headers={"Accept-Ranges": "bytes", "Cache-Control": "no-store"},
         )
 
     match = re.match(r"bytes=(\d+)-(\d*)", range_header)
@@ -207,6 +215,7 @@ async def get_download(id: str, request: Request):
             "Content-Range": f"bytes {start}-{end}/{file_size}",
             "Accept-Ranges": "bytes",
             "Content-Length": str(chunk_size),
+            "Cache-Control": "no-store",
         },
     )
 

--- a/songbirdapi/routers/edit.py
+++ b/songbirdapi/routers/edit.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import shutil
 import uuid as _uuid
@@ -86,6 +87,10 @@ async def _run_edit_job(
     overwrite: bool,
     as_original: bool = False,
 ) -> None:
+    # Sessions are scoped tightly here: setup-read → release → ffmpeg/tag IO →
+    # finalize-write. Earlier this whole job ran inside one session_scope,
+    # which pinned a pool connection for the entire ffmpeg duration
+    # (seconds-minutes) and saturated the pool under concurrent edits.
     async with database.session_scope() as db:
         await crud.update_edit_job(db, job_id, EditJobStatus.processing)
 
@@ -106,18 +111,38 @@ async def _run_edit_job(
             ):
                 merged_props["collectionId"] = str(merged_props["collectionId"])
 
-        if overwrite:
-            dest_path = source.file_path
-            base, ext = os.path.splitext(dest_path)
-            tmp_path = f"{base}_tmp{ext}"
-            try:
-                await apply_edits(source.file_path, tmp_path, params)
-                os.replace(tmp_path, dest_path)
+        # Snapshot what we need post-IO so the session can be released.
+        source_file_path = source.file_path
+        source_uuid = source.uuid
+        source_url = source.url
+        source_owner_id = source.owner_id
+        source_artwork_thumb = source.artwork_thumb
+        source_artwork_full = source.artwork_full
+        source_parent_song_id = source.parent_song_id
+        source_properties = source.properties
+        root_id = source.root_song_id or source.uuid
+        if not overwrite and root_id != source_uuid:
+            root = await crud.get_song(db, root_id)
+            root_file_path = root.file_path if root else source_file_path
+        else:
+            root_file_path = source_file_path
+
+    if overwrite:
+        dest_path = source_file_path
+        base, ext = os.path.splitext(dest_path)
+        tmp_path = f"{base}_tmp{ext}"
+        try:
+            await apply_edits(source_file_path, tmp_path, params)
+            os.replace(tmp_path, dest_path)
+            if merged_props is not None:
+                await asyncio.to_thread(_retag_file, dest_path, merged_props)
+            async with database.session_scope() as db:
                 if merged_props is not None:
-                    _retag_file(dest_path, merged_props)
-                    await crud.update_song_properties(db, source_song_id, merged_props)
-                    if source.owner_id == user_id and crud._is_publish_eligible(
-                        merged_props, artwork_cached=source.artwork_thumb is not None
+                    await crud.update_song_properties(
+                        db, source_song_id, merged_props
+                    )
+                    if source_owner_id == user_id and crud._is_publish_eligible(
+                        merged_props, artwork_cached=source_artwork_thumb is not None
                     ):
                         await crud.publish_song(
                             db, source_song_id, as_original=as_original
@@ -125,35 +150,29 @@ async def _run_edit_job(
                 await crud.update_edit_job(
                     db, job_id, EditJobStatus.done, result_song_id=source_song_id
                 )
-            except Exception as exc:
-                if os.path.exists(tmp_path):
-                    os.remove(tmp_path)
+        except Exception as exc:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            async with database.session_scope() as db:
                 await crud.update_edit_job(
                     db, job_id, EditJobStatus.failed, error=str(exc)
                 )
-        else:
-            # Always edit from the root original to avoid compounding generation loss.
-            root_id = source.root_song_id or source.uuid
-            root = (
-                await crud.get_song(db, root_id) if root_id != source.uuid else source
-            )
-
-            new_uuid = str(_uuid.uuid4())
-            dest_path = os.path.join(_config.downloads_dir, f"{new_uuid}.mp3")
-            try:
-                await apply_edits(root.file_path, dest_path, params)
-                final_props = (
-                    merged_props if merged_props is not None else source.properties
-                )
-                if merged_props is not None:
-                    _retag_file(dest_path, merged_props)
+    else:
+        new_uuid = str(_uuid.uuid4())
+        dest_path = os.path.join(_config.downloads_dir, f"{new_uuid}.mp3")
+        try:
+            await apply_edits(root_file_path, dest_path, params)
+            final_props = merged_props if merged_props is not None else source_properties
+            if merged_props is not None:
+                await asyncio.to_thread(_retag_file, dest_path, merged_props)
+            async with database.session_scope() as db:
                 new_song = Song(
                     uuid=new_uuid,
-                    url=source.url,
+                    url=source_url,
                     file_path=dest_path,
                     properties=final_props,
-                    artwork_thumb=source.artwork_thumb,
-                    artwork_full=source.artwork_full,
+                    artwork_thumb=source_artwork_thumb,
+                    artwork_full=source_artwork_full,
                     parent_song_id=source_song_id,
                     root_song_id=root_id,
                     owner_id=user_id,
@@ -166,24 +185,25 @@ async def _run_edit_job(
 
                 # Enforce 2-edit cap: delete the old grandparent (pre-last-save) if it
                 # is not the root and has no other library references.
-                if source.parent_song_id and source.parent_song_id != root_id:
+                if source_parent_song_id and source_parent_song_id != root_id:
                     if (
-                        await crud.library_ref_count(db, source.parent_song_id) == 0
-                        and await crud.child_ref_count(db, source.parent_song_id) == 0
+                        await crud.library_ref_count(db, source_parent_song_id) == 0
+                        and await crud.child_ref_count(db, source_parent_song_id) == 0
                     ):
-                        await crud.delete_song(db, source.parent_song_id)
+                        await crud.delete_song(db, source_parent_song_id)
 
                 await crud.add_to_library(db, user_id, new_uuid)
                 if merged_props is not None and crud._is_publish_eligible(
-                    merged_props, artwork_cached=source.artwork_thumb is not None
+                    merged_props, artwork_cached=source_artwork_thumb is not None
                 ):
                     await crud.publish_song(db, new_uuid, as_original=as_original)
                 await crud.update_edit_job(
                     db, job_id, EditJobStatus.done, result_song_id=new_uuid
                 )
-            except Exception as exc:
-                if os.path.exists(dest_path):
-                    os.remove(dest_path)
+        except Exception as exc:
+            if os.path.exists(dest_path):
+                os.remove(dest_path)
+            async with database.session_scope() as db:
                 await crud.update_edit_job(
                     db, job_id, EditJobStatus.failed, error=str(exc)
                 )

--- a/songbirdapi/routers/edit.py
+++ b/songbirdapi/routers/edit.py
@@ -138,9 +138,7 @@ async def _run_edit_job(
                 await asyncio.to_thread(_retag_file, dest_path, merged_props)
             async with database.session_scope() as db:
                 if merged_props is not None:
-                    await crud.update_song_properties(
-                        db, source_song_id, merged_props
-                    )
+                    await crud.update_song_properties(db, source_song_id, merged_props)
                     if source_owner_id == user_id and crud._is_publish_eligible(
                         merged_props, artwork_cached=source_artwork_thumb is not None
                     ):
@@ -162,7 +160,9 @@ async def _run_edit_job(
         dest_path = os.path.join(_config.downloads_dir, f"{new_uuid}.mp3")
         try:
             await apply_edits(root_file_path, dest_path, params)
-            final_props = merged_props if merged_props is not None else source_properties
+            final_props = (
+                merged_props if merged_props is not None else source_properties
+            )
             if merged_props is not None:
                 await asyncio.to_thread(_retag_file, dest_path, merged_props)
             async with database.session_scope() as db:

--- a/songbirdapi/routers/imports.py
+++ b/songbirdapi/routers/imports.py
@@ -199,7 +199,6 @@ async def start_import(
     background_tasks: BackgroundTasks,
     file: UploadFile = File(...),
     as_original: bool = Query(default=False),
-    db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> ImportJobResponse:
     ext = os.path.splitext(file.filename or "")[1].lower()
@@ -214,15 +213,21 @@ async def start_import(
     new_uuid = str(uuid.uuid4())
     dest_path = os.path.join(_config.downloads_dir, f"{new_uuid}{ext}")
 
+    # Read upload body and write to disk WITHOUT holding a DB session — large
+    # uploads otherwise pin a pool connection for the duration of the body
+    # transfer, which exhausts the pool under concurrent imports.
     content = await file.read()
     with open(dest_path, "wb") as f:
         f.write(content)
 
-    job = await crud.create_import_job(db, current_user.id, file.filename or "")
+    async with database.session_scope() as db:
+        job = await crud.create_import_job(db, current_user.id, file.filename or "")
+        job_id = job.id
+        job_status = job.status.value
     background_tasks.add_task(
-        _run_import, job.id, dest_path, ext, current_user.id, as_original
+        _run_import, job_id, dest_path, ext, current_user.id, as_original
     )
-    return ImportJobResponse(job_id=job.id, status=job.status.value)
+    return ImportJobResponse(job_id=job_id, status=job_status)
 
 
 @router.get("/{job_id}")

--- a/songbirdapi/routers/properties.py
+++ b/songbirdapi/routers/properties.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from typing import Annotated, List, Optional, Union
@@ -12,6 +13,7 @@ from songbirdcore.models.modes import Modes
 
 from songbirdapi import crud
 from ..crud import _is_publish_eligible, _get_missing_fields
+from ..database import session_scope
 from ..dependencies import get_current_user, get_db, load_settings
 from ..models import Role, User
 
@@ -168,40 +170,46 @@ async def _cache_artwork(song_id: str, itunes_url: str) -> None:
 async def put_properties(
     body: TagBody,
     background_tasks: BackgroundTasks,
-    db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> TagResponse:
-    song = await crud.get_song(db, body.song_id)
-    if not song:
-        msg = f"Cannot tag song w/ id {body.song_id}, it has not been downloaded yet!"
-        logger.error(msg)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
-    if not os.path.exists(song.file_path):
-        msg = f"Cannot tag file {song.file_path}, file does not exist"
-        logger.error(msg)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg
-        )
+    # Open session only for the initial read, release before sync file
+    # tagging (mp3ID3Tagger/m4a_tagger are blocking IO), then re-open for
+    # the writes. Holding a session across blocking tagger calls pins a
+    # pool connection for hundreds of ms per save and exhausts the pool
+    # under concurrent edits.
+    async with session_scope() as db:
+        song = await crud.get_song(db, body.song_id)
+        if not song:
+            msg = f"Cannot tag song w/ id {body.song_id}, it has not been downloaded yet!"
+            logger.error(msg)
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
+        if not os.path.exists(song.file_path):
+            msg = f"Cannot tag file {song.file_path}, file does not exist"
+            logger.error(msg)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg
+            )
+        file_path = song.file_path
+        existing_artwork_url = (song.properties or {}).get("artworkUrl100", "")
+
     artwork_url = body.properties.artworkUrl100 or ""
     if not artwork_url.startswith("http"):
-        artwork_url = (song.properties or {}).get("artworkUrl100", "")
+        artwork_url = existing_artwork_url
 
-    ext = os.path.splitext(song.file_path)[1].lower()
+    ext = os.path.splitext(file_path)[1].lower()
     if artwork_url.startswith("http"):
         props_for_tagging = body.properties.model_copy(
             update={"artworkUrl100": artwork_url}
         )
-        result = (
-            itunes.mp3ID3Tagger(song.file_path, props_for_tagging)
-            if ext == ".mp3"
-            else itunes.m4a_tagger(song.file_path, props_for_tagging)
-        )
+        tagger = itunes.mp3ID3Tagger if ext == ".mp3" else itunes.m4a_tagger
+        result = await asyncio.to_thread(tagger, file_path, props_for_tagging)
     else:
-        result = (
-            itunes.mp3ID3TaggerNoArtwork(song.file_path, body.properties)
+        tagger = (
+            itunes.mp3ID3TaggerNoArtwork
             if ext == ".mp3"
-            else itunes.m4aID3TaggerNoArtwork(song.file_path, body.properties)
+            else itunes.m4aID3TaggerNoArtwork
         )
+        result = await asyncio.to_thread(tagger, file_path, body.properties)
 
     if not result:
         raise HTTPException(
@@ -211,20 +219,23 @@ async def put_properties(
 
     props = body.properties.model_dump()
     props["collectionId"] = str(props["collectionId"])
-    await crud.update_song_properties(db, body.song_id, props)
+
+    async with session_scope() as db:
+        await crud.update_song_properties(db, body.song_id, props)
+        song = await crud.get_song(db, body.song_id)
+        if (
+            song
+            and song.owner_id == current_user.id
+            and _is_publish_eligible(
+                props, artwork_cached=song.artwork_thumb is not None
+            )
+        ):
+            as_original = body.as_original and current_user.role == Role.admin
+            await crud.publish_song(db, body.song_id, as_original=as_original)
 
     if body.properties.artworkUrl100:
         background_tasks.add_task(
             _cache_artwork, body.song_id, body.properties.artworkUrl100
         )
-
-    song = await crud.get_song(db, body.song_id)
-    if (
-        song
-        and song.owner_id == current_user.id
-        and _is_publish_eligible(props, artwork_cached=song.artwork_thumb is not None)
-    ):
-        as_original = body.as_original and current_user.role == Role.admin
-        await crud.publish_song(db, body.song_id, as_original=as_original)
 
     return TagResponse(song_id=body.song_id)

--- a/songbirdapi/routers/properties.py
+++ b/songbirdapi/routers/properties.py
@@ -180,7 +180,9 @@ async def put_properties(
     async with session_scope() as db:
         song = await crud.get_song(db, body.song_id)
         if not song:
-            msg = f"Cannot tag song w/ id {body.song_id}, it has not been downloaded yet!"
+            msg = (
+                f"Cannot tag song w/ id {body.song_id}, it has not been downloaded yet!"
+            )
             logger.error(msg)
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
         if not os.path.exists(song.file_path):

--- a/songbirdapi/routers/songs.py
+++ b/songbirdapi/routers/songs.py
@@ -219,18 +219,20 @@ async def get_artwork(
 async def upload_artwork(
     id: str,
     file: UploadFile = File(...),
-    db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    song = await crud.get_song(db, id)
-    if not song:
-        raise HTTPException(status_code=404, detail="Song not found")
-    if (
-        song.owner_id
-        and song.owner_id != current_user.id
-        and current_user.role.value != "admin"
-    ):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    # Authorization check first, then release session before reading body and
+    # storing artwork so we don't pin a pool connection during the upload.
+    async with session_scope() as db:
+        song = await crud.get_song(db, id)
+        if not song:
+            raise HTTPException(status_code=404, detail="Song not found")
+        if (
+            song.owner_id
+            and song.owner_id != current_user.id
+            and current_user.role.value != "admin"
+        ):
+            raise HTTPException(status_code=403, detail="Forbidden")
 
     MAX_ARTWORK_BYTES = 10 * 1024 * 1024  # 10 MB
     if file.size is not None and file.size > MAX_ARTWORK_BYTES:
@@ -251,6 +253,8 @@ async def upload_artwork(
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    await crud.update_song_artwork(db, id, thumb_path, full_path)
+
+    async with session_scope() as db:
+        await crud.update_song_artwork(db, id, thumb_path, full_path)
 
     return {"ok": True}

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.8"
+version = "v0.0.9"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,8 +4,6 @@ import uuid
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
 from songbirdapi import crud, database
 from songbirdapi.database import get_db
 from songbirdapi.models import Base, Role, Song, User
@@ -31,15 +29,14 @@ def pytest_collection_modifyitems(config, items):
 
 # One engine created at import time (sync, no event loop required).
 # Overriding get_db means both fixtures and app routes share this engine/pool.
+# Use database.init_engine so the integration suite exercises the SAME pool
+# config (size/recycle/server_settings) as production — otherwise the pool
+# tests in test_pool.py would validate sqlalchemy defaults instead of
+# what we actually ship.
 _config = SongbirdServerConfig()  # pyright: ignore
-_engine = create_async_engine(_config.postgres_dsn)
-_TestingSession = async_sessionmaker(_engine, expire_on_commit=False)
-
-# Initialize the module-level session factory so background tasks (edit/imports)
-# and the unhandled-exception handler in server.py can open sessions even though
-# the FastAPI lifespan never runs under ASGITransport.
-database._engine = _engine
-database._session_factory = _TestingSession
+database.init_engine(_config.postgres_dsn)
+_engine = database._engine
+_TestingSession = database._session_factory
 
 
 async def _override_get_db():

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -51,9 +51,9 @@ async def test_read_endpoint_releases_connection_after_response(
     # flight when this line runs the next time, but with no in-flight
     # request the count must equal baseline.
     await asyncio.sleep(0.05)
-    assert _checkedout() == baseline, (
-        f"connection leaked: baseline={baseline}, after 50 reads={_checkedout()}"
-    )
+    assert (
+        _checkedout() == baseline
+    ), f"connection leaked: baseline={baseline}, after 50 reads={_checkedout()}"
 
 
 async def test_write_endpoint_releases_connection_after_response(
@@ -65,9 +65,7 @@ async def test_write_endpoint_releases_connection_after_response(
     baseline = _checkedout()
     for _ in range(20):
         # Add then remove — idempotent loop, doesn't leak rows.
-        r1 = await test_client.post(
-            f"/v1/library/{sample_song.uuid}", cookies=cookies
-        )
+        r1 = await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
         assert r1.status_code == 201
         r2 = await test_client.delete(
             f"/v1/library/{sample_song.uuid}", cookies=cookies
@@ -86,9 +84,7 @@ async def test_endpoint_raising_404_releases_connection(
     cookies = await _login(test_client, regular_user)
     baseline = _checkedout()
     for _ in range(50):
-        resp = await test_client.get(
-            "/v1/songs/does-not-exist-xyz", cookies=cookies
-        )
+        resp = await test_client.get("/v1/songs/does-not-exist-xyz", cookies=cookies)
         assert resp.status_code == 404
     await asyncio.sleep(0.05)
     assert _checkedout() == baseline

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -1,0 +1,154 @@
+"""
+Pool/connection-handling regression tests.
+
+Background: under e2e load we hit pool exhaustion + the asyncpg
+"cannot switch to state 15" race. The fix combined:
+  - bcrypt offload to asyncio.to_thread (was blocking the loop)
+  - pool_pre_ping=False (was racing pg_idle_in_transaction_session_timeout)
+  - pool_recycle=600s + pg-side idle_in_tx timeout=120s as a self-heal net
+  - session_scope rolls back in finally so read-only / autobegan tx release
+  - streaming/IO endpoints (downloads, artwork, share download, edit job,
+    properties tagger, imports upload) release the session before the
+    blocking IO so the connection isn't pinned for the duration
+
+These tests lock in those guarantees by introspecting engine.pool directly.
+The conftest.py engine is shared with the app via database._engine override,
+so engine.pool.checkedout() reflects what the routes see.
+"""
+
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+
+from songbirdapi import database
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+def _checkedout() -> int:
+    return database._engine.pool.checkedout()
+
+
+async def _login(test_client: AsyncClient, user) -> dict:
+    resp = await test_client.post(
+        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+    )
+    return dict(resp.cookies)
+
+
+async def test_read_endpoint_releases_connection_after_response(
+    test_client: AsyncClient, regular_user
+):
+    """A read endpoint must return its connection to the pool when the
+    response completes. Loops 50× to expose any per-request leak."""
+    cookies = await _login(test_client, regular_user)
+    baseline = _checkedout()
+    for _ in range(50):
+        resp = await test_client.get("/v1/library", cookies=cookies)
+        assert resp.status_code == 200
+    # Allow one in-flight settle — the test client's own request is in
+    # flight when this line runs the next time, but with no in-flight
+    # request the count must equal baseline.
+    await asyncio.sleep(0.05)
+    assert _checkedout() == baseline, (
+        f"connection leaked: baseline={baseline}, after 50 reads={_checkedout()}"
+    )
+
+
+async def test_write_endpoint_releases_connection_after_response(
+    test_client: AsyncClient, regular_user, sample_song
+):
+    """Write paths commit then return — the commit clears the autobegan
+    tx, and session close releases the connection. Verify by looping."""
+    cookies = await _login(test_client, regular_user)
+    baseline = _checkedout()
+    for _ in range(20):
+        # Add then remove — idempotent loop, doesn't leak rows.
+        r1 = await test_client.post(
+            f"/v1/library/{sample_song.uuid}", cookies=cookies
+        )
+        assert r1.status_code == 201
+        r2 = await test_client.delete(
+            f"/v1/library/{sample_song.uuid}", cookies=cookies
+        )
+        assert r2.status_code == 204
+    await asyncio.sleep(0.05)
+    assert _checkedout() == baseline
+
+
+async def test_endpoint_raising_404_releases_connection(
+    test_client: AsyncClient, regular_user
+):
+    """When an endpoint raises HTTPException mid-handler, FastAPI still
+    runs the get_db dependency cleanup. session_scope's finally rollback
+    must fire so the connection returns to the pool."""
+    cookies = await _login(test_client, regular_user)
+    baseline = _checkedout()
+    for _ in range(50):
+        resp = await test_client.get(
+            "/v1/songs/does-not-exist-xyz", cookies=cookies
+        )
+        assert resp.status_code == 404
+    await asyncio.sleep(0.05)
+    assert _checkedout() == baseline
+
+
+async def test_concurrent_burst_does_not_exhaust_pool(
+    test_client: AsyncClient, regular_user
+):
+    """50 concurrent /v1/library reads against pool_size=20 + max_overflow=10
+    must all complete (overflow + queueing handles the surge). If any
+    request blocks indefinitely or 500s, the pool is mishandled."""
+    cookies = await _login(test_client, regular_user)
+    baseline = _checkedout()
+
+    async def one():
+        r = await test_client.get("/v1/library", cookies=cookies)
+        assert r.status_code == 200
+
+    await asyncio.gather(*(one() for _ in range(50)))
+    await asyncio.sleep(0.1)
+    assert _checkedout() == baseline
+
+
+async def test_streaming_artwork_releases_session_before_stream(
+    test_client: AsyncClient, regular_user, sample_song
+):
+    """Streaming endpoints (artwork, downloads, share) wrap the DB read in
+    session_scope so the connection is released BEFORE the FileResponse
+    is returned. Verifies the migration we did to fix /library 50-fanout
+    pool exhaustion. We use a 404 path here because sample_song has no
+    artwork file — we just need the route to do its DB lookup and return
+    without holding a connection."""
+    cookies = await _login(test_client, regular_user)
+    baseline = _checkedout()
+    # 404 is fine — handler still goes through session_scope read path
+    for _ in range(30):
+        resp = await test_client.get(
+            f"/v1/songs/{sample_song.uuid}/artwork/full", cookies=cookies
+        )
+        assert resp.status_code == 404
+    await asyncio.sleep(0.05)
+    assert _checkedout() == baseline
+
+
+async def test_pool_size_within_configured_limits(test_client: AsyncClient):
+    """Smoke test: under no load, pool should never exceed configured size.
+    pool.size() reports persistent connections (capped at pool_size=20).
+    Catches drift if someone changes init_engine without updating the
+    integration tests' baseline."""
+    # No requests in flight here — pool should be near zero checkedout.
+    assert _checkedout() <= database._engine.pool.size()
+
+
+async def test_health_endpoint_releases_db_session(test_client: AsyncClient):
+    """The /v1/health endpoint runs SELECT 1 via Depends(get_db). If that
+    leaks a connection per call, an external monitor probing /health every
+    few seconds drains the pool over hours. Verify by hammering it."""
+    baseline = _checkedout()
+    for _ in range(100):
+        resp = await test_client.get("/v1/health")
+        assert resp.status_code == 200
+    await asyncio.sleep(0.05)
+    assert _checkedout() == baseline

--- a/uv.lock
+++ b/uv.lock
@@ -1741,7 +1741,7 @@ wheels = [
 
 [[package]]
 name = "songbirdapi"
-version = "0.0.8"
+version = "0.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- 4 endpoints now scope DB sessions tightly so blocking IO (ffmpeg, file uploads, sync taggers) doesn't pin a pool connection: imports.start_import, songs.upload_artwork, properties.put_properties, edit._run_edit_job
- downloads endpoint sends `Cache-Control: no-store` to avoid chromium's HTTP cache write race on concurrent same-URL fetches (was leaving the editor preview button permanently disabled in tests)
- new `tests/integration/test_pool.py` — 7 regression tests covering connection release on read/write/error paths, concurrent burst, streaming endpoints, and /v1/health
- conftest now uses `database.init_engine` so integration tests run against the SAME pool config as production (pool_size=20, recycle=600, idle_in_tx=120s, no pre_ping)

## Test plan
- [x] all 148 integration tests pass (`make test-integration`)
- [x] new pool tests pass standalone (`pytest tests/integration/test_pool.py`)
- [x] e2e dev suite passes (151+/153, 2 fixed)
- [x] e2e prod suite 8/8 pass
