### PR TITLE
ci: concurrency + issue templates + bump v0.0.10

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Something is broken in the songbird API backend
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! The more context you give, the faster we can fix it.
+
+  - type: input
+    id: api-version
+    attributes:
+      label: songbirdapi version
+      description: Output of `GET /v1/version` or the docker image tag you're running
+      placeholder: "v0.0.9"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Where is the API running?
+      options:
+        - "Production (keebox / songbird.kee-flix.com)"
+        - "Local dev (uvicorn --reload)"
+        - "Local Docker"
+        - "Self-hosted Docker"
+        - "Other"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Only required for local dev / self-hosted
+      placeholder: "3.13.1"
+
+  - type: input
+    id: endpoint
+    attributes:
+      label: Endpoint + method
+      placeholder: "POST /v1/import"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Include the response status and body. Redact secrets.
+      placeholder: "Got 500. Response body: {\"detail\":\"...\"}"
+    validations:
+      required: true
+
+  - type: textarea
+    id: request
+    attributes:
+      label: Request that triggered it
+      description: Method, headers (no auth tokens), body. Or a curl command.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: server-logs
+    attributes:
+      label: Server logs / traceback
+      description: For self-hosters — `docker logs songbirdapi` around the time of the error
+      render: shell
+
+  - type: dropdown
+    id: reproducible
+    attributes:
+      label: Reproducibility
+      options:
+        - "Every time"
+        - "Sometimes / flaky"
+        - "Once"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest a new endpoint or capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      placeholder: "I need to do X but the API doesn't expose Y..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed endpoint or behavior
+      description: Method + path + request/response shape if you have a concrete idea
+      placeholder: "GET /v1/foo/bar — returns list of ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds with the existing API?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Affected area
+      options:
+        - "Auth / users"
+        - "Library / songs"
+        - "Downloads"
+        - "Imports"
+        - "Editor / edit jobs"
+        - "Properties / tagging"
+        - "Sharing"
+        - "Playlists"
+        - "Player state"
+        - "Admin"
+        - "Cross-cutting"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   version-check:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.9"
+version = "0.0.10"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.9"
+version = "v0.0.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1741,7 +1741,7 @@ wheels = [
 
 [[package]]
 name = "songbirdapi"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1799,7 +1799,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "songbirdcore"
-version = "0.1.9"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1818,9 +1818,9 @@ dependencies = [
     { name = "requests-htmlc" },
     { name = "yt-dlp", extra = ["default"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/d5/bce32dee7adf494d946cc0792077061f7531dd435a832e014a230508c0b4/songbirdcore-0.1.9.tar.gz", hash = "sha256:3a00a691d147d849a3fa5827b022f2cb4557f3c59ad28101e310d851b0d0b974", size = 435010, upload-time = "2026-04-29T05:27:57.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/fb/1ec323fef7326999ac7f2aeb377f971cc5d1120c71cdae4fe17234fe97c4/songbirdcore-0.1.10.tar.gz", hash = "sha256:61cd0407a3bea75a73050af2982af773182d6fa0170b7b39416129b7fac00c25", size = 436408, upload-time = "2026-04-30T15:32:51.619Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/70/a525b8b6669b201b466484ce77b6f4d69a71bffcb1f3c4cd50a2e524dc1e/songbirdcore-0.1.9-py3-none-any.whl", hash = "sha256:b5c43dc7260f5bd76cf76ea95267b15d93ab8b05fca6e944996479dee5b2f67d", size = 316458, upload-time = "2026-04-29T05:27:56.072Z" },
+    { url = "https://files.pythonhosted.org/packages/af/12/c1e1acc297c95ab37875f0e752abda905f796bec99551cc05485ad4baaf1/songbirdcore-0.1.10-py3-none-any.whl", hash = "sha256:cd2f87a12b1fd7aeb5329d8206ec8cc4280839530b02c68be5e57c1c46a79faf", size = 316468, upload-time = "2026-04-30T15:32:50.184Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `concurrency:` block to all workflows so new pushes auto-cancel older runs (test, style, version-check use cancel-in-progress; docker exempts main/tag pushes so deploys never abort)
- Adds `.github/ISSUE_TEMPLATE/` with bug + feature forms tailored to songbirdapi (api version, deployment, endpoint, request/response, server logs)
- Bumps v0.0.9 → v0.0.10 to satisfy version-check