### PR TITLE
fix(imports): correct created_at server_default to use now() function

### DIFF
--- a/migrations/versions/a1b2c3d4e5f6_fix_import_jobs_created_at_default.py
+++ b/migrations/versions/a1b2c3d4e5f6_fix_import_jobs_created_at_default.py
@@ -18,12 +18,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "ALTER TABLE import_jobs ALTER COLUMN created_at SET DEFAULT now()"
-    )
-    op.execute(
-        "ALTER TABLE import_jobs ALTER COLUMN updated_at SET DEFAULT now()"
-    )
+    op.execute("ALTER TABLE import_jobs ALTER COLUMN created_at SET DEFAULT now()")
+    op.execute("ALTER TABLE import_jobs ALTER COLUMN updated_at SET DEFAULT now()")
 
 
 def downgrade() -> None:

--- a/migrations/versions/a1b2c3d4e5f6_fix_import_jobs_created_at_default.py
+++ b/migrations/versions/a1b2c3d4e5f6_fix_import_jobs_created_at_default.py
@@ -1,0 +1,30 @@
+"""fix import_jobs created_at/updated_at default to use now() function
+
+Revision ID: a1b2c3d4e5f6
+Revises: 2f5adcc84df4
+Create Date: 2026-04-30 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "2f5adcc84df4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE import_jobs ALTER COLUMN created_at SET DEFAULT now()"
+    )
+    op.execute(
+        "ALTER TABLE import_jobs ALTER COLUMN updated_at SET DEFAULT now()"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.10"
+version = "0.0.11"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/models.py
+++ b/songbirdapi/models.py
@@ -243,10 +243,10 @@ class ImportJob(Base):
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
     duplicate_of: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
 

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.10"
+version = "v0.0.11"


### PR DESCRIPTION
## Summary
- `import_jobs.created_at` (and `updated_at`) had a frozen literal timestamp as their DB default — every new import job was getting `2026-04-29 06:32:27` as `created_at`
- Root cause: alembic baseline used `server_default="now()"` (plain string), which PostgreSQL evaluated as a string literal at migration time rather than a per-row function call
- Adds migration `a1b2c3d4e5f6` to `ALTER COLUMN ... SET DEFAULT now()` on both columns
- Fixes `models.py` to use `server_default=func.now()` so clean installs are correct going forward

## Impact
- Import jobs were buried in paginated results (all 3990 existing jobs shared the same timestamp), so the frontend poller never found newly submitted jobs on page 1 — imports appeared stuck forever
- After this fix, new jobs get correct timestamps and sort to the top

## Test plan
- [ ] Import a song — job reaches terminal status (done/failed/duplicate) and UI updates correctly