### PR TITLE
feat: offline cleanup + player state updated_at

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+echo "pre-commit: checking formatting..."
+make lint-check
+
+# version-check only meaningful on feature branches (not main)
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" != "main" ]; then
+    echo "pre-commit: checking version bump..."
+    make version-check
+fi

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ APP_NAME=songbirdapi
 .PHONY: setup
 setup:
 	uv sync --extra dev
+	git config core.hooksPath .githooks
 
 .PHONY: upgrade
 upgrade:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,24 @@ upgrade:
 
 .PHONY: lint
 lint:
-	uv run black $(APP_NAME)/.
+	uv run black .
+
+.PHONY: lint-check
+lint-check:
+	uv run black --check .
+
+.PHONY: version-check
+version-check:
+	@MAIN_VERSION=$$(git show origin/main:$(APP_NAME)/version.py 2>/dev/null | grep '^version' | cut -d'"' -f2) && \
+	PR_VERSION=$$(grep '^version' $(APP_NAME)/version.py | cut -d'"' -f2) && \
+	MAIN_PYPROJECT=$$(git show origin/main:pyproject.toml 2>/dev/null | grep '^version' | head -1 | cut -d'"' -f2) && \
+	PR_PYPROJECT=$$(grep '^version' pyproject.toml | head -1 | cut -d'"' -f2) && \
+	if [ "$$MAIN_VERSION" = "$$PR_VERSION" ]; then echo "ERROR: version.py not bumped ($$PR_VERSION)"; exit 1; fi && \
+	if [ "$$MAIN_PYPROJECT" = "$$PR_PYPROJECT" ]; then echo "ERROR: pyproject.toml not bumped ($$PR_PYPROJECT)"; exit 1; fi && \
+	echo "OK: $$MAIN_VERSION -> $$PR_VERSION"
+
+.PHONY: pre-commit
+pre-commit: lint-check version-check
 
 .PHONY: test
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.11"
+version = "0.0.12"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/crud.py
+++ b/songbirdapi/crud.py
@@ -820,6 +820,147 @@ async def upsert_player_state(
     return state
 
 
+async def queue_insert(
+    db: AsyncSession,
+    user_id: str,
+    song_id: str,
+    position: int | None = None,
+    source: dict | None = None,
+) -> UserPlayerState:
+    state = await get_player_state(db, user_id)
+    if state is None:
+        state = UserPlayerState(user_id=user_id)
+        db.add(state)
+
+    queue = list(state.queue)
+    if song_id in queue:
+        return state
+
+    pos = position if position is not None else len(queue)
+    pos = max(0, min(pos, len(queue)))
+    queue.insert(pos, song_id)
+    state.queue = queue
+
+    if state.shuffle and state.shuffle_order is not None:
+        order = [i + 1 if i >= pos else i for i in state.shuffle_order]
+        order.append(pos)
+        state.shuffle_order = order
+
+    if pos <= state.queue_index:
+        state.queue_index += 1
+
+    if source:
+        sources = dict(state.queue_sources or {})
+        sources[song_id] = source
+        state.queue_sources = sources
+
+    state.updated_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(state)
+    return state
+
+
+async def queue_remove(
+    db: AsyncSession,
+    user_id: str,
+    song_id: str,
+) -> UserPlayerState:
+    state = await get_player_state(db, user_id)
+    if state is None:
+        return UserPlayerState(user_id=user_id)
+
+    queue = list(state.queue)
+    if song_id not in queue:
+        return state
+
+    index = queue.index(song_id)
+    queue.pop(index)
+    state.queue = queue
+
+    if state.shuffle and state.shuffle_order is not None:
+        removed_pos = None
+        for i, v in enumerate(state.shuffle_order):
+            if v == index:
+                removed_pos = i
+                break
+        order = [i for i in state.shuffle_order if i != index]
+        order = [i - 1 if i > index else i for i in order]
+        state.shuffle_order = order
+        if removed_pos is not None and removed_pos < (state.shuffle_position or 0):
+            state.shuffle_position = max(0, (state.shuffle_position or 0) - 1)
+
+    if index < state.queue_index:
+        state.queue_index -= 1
+    elif index == state.queue_index:
+        state.queue_index = min(state.queue_index, max(0, len(queue) - 1))
+
+    manual = list(state.manual_next or [])
+    if song_id in manual:
+        manual.remove(song_id)
+        state.manual_next = manual
+
+    sources = dict(state.queue_sources or {})
+    sources.pop(song_id, None)
+    state.queue_sources = sources
+
+    state.updated_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(state)
+    return state
+
+
+async def queue_reorder(
+    db: AsyncSession,
+    user_id: str,
+    from_position: int,
+    to_position: int,
+) -> UserPlayerState:
+    state = await get_player_state(db, user_id)
+    if state is None:
+        return UserPlayerState(user_id=user_id)
+
+    if from_position == to_position or from_position == to_position - 1:
+        return state
+
+    if state.shuffle and state.shuffle_order is not None:
+        order = list(state.shuffle_order)
+        if from_position < 0 or from_position >= len(order):
+            return state
+        moved = order.pop(from_position)
+        insert_at = to_position - 1 if to_position > from_position else to_position
+        insert_at = max(0, min(insert_at, len(order)))
+        order.insert(insert_at, moved)
+        state.shuffle_order = order
+
+        current_uuid = state.current_song_uuid
+        if current_uuid and current_uuid in state.queue:
+            qi = state.queue.index(current_uuid)
+            new_pos = order.index(qi) if qi in order else (state.shuffle_position or 0)
+            state.shuffle_position = new_pos
+    else:
+        queue = list(state.queue)
+        if from_position < 0 or from_position >= len(queue):
+            return state
+        item = queue.pop(from_position)
+        insert_at = to_position - 1 if to_position > from_position else to_position
+        insert_at = max(0, min(insert_at, len(queue)))
+        queue.insert(insert_at, item)
+        state.queue = queue
+
+        current_idx = state.queue_index
+        if from_position == current_idx:
+            state.queue_index = insert_at
+        elif from_position < current_idx <= insert_at:
+            state.queue_index -= 1
+        elif insert_at <= current_idx < from_position:
+            state.queue_index += 1
+
+    state.updated_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(state)
+    return state
+
+
 # --- Playlists ---
 
 

--- a/songbirdapi/crud.py
+++ b/songbirdapi/crud.py
@@ -254,6 +254,11 @@ async def remove_from_library(db: AsyncSession, user_id: str, song_id: str) -> b
     result = await db.execute(
         delete(UserSong).where(UserSong.user_id == user_id, UserSong.song_id == song_id)
     )
+    await db.execute(
+        delete(UserOfflineSong).where(
+            UserOfflineSong.user_id == user_id, UserOfflineSong.song_id == song_id
+        )
+    )
     await db.commit()
     return result.rowcount > 0
 
@@ -264,6 +269,11 @@ async def bulk_remove_from_library(
     await db.execute(
         delete(UserSong).where(
             UserSong.user_id == user_id, UserSong.song_id.in_(song_ids)
+        )
+    )
+    await db.execute(
+        delete(UserOfflineSong).where(
+            UserOfflineSong.user_id == user_id, UserOfflineSong.song_id.in_(song_ids)
         )
     )
     await db.commit()

--- a/songbirdapi/routers/player.py
+++ b/songbirdapi/routers/player.py
@@ -1,4 +1,5 @@
-from typing import Literal
+from datetime import datetime
+from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
@@ -30,6 +31,7 @@ class PlayerState(BaseModel):
     manual_next: list[str] = Field(default_factory=list)
     current_song_uuid: str | None = None
     queue_sources: dict[str, QueueSource] = Field(default_factory=dict)
+    updated_at: Optional[datetime] = None
 
 
 def _serialize(state) -> PlayerState:
@@ -45,6 +47,7 @@ def _serialize(state) -> PlayerState:
         manual_next=state.manual_next or [],
         current_song_uuid=state.current_song_uuid,
         queue_sources=state.queue_sources or {},
+        updated_at=state.updated_at,
     )
 
 

--- a/songbirdapi/routers/player.py
+++ b/songbirdapi/routers/player.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Literal, Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Path
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -82,5 +82,54 @@ async def update_state(
         body.manual_next,
         body.current_song_uuid,
         {k: v.model_dump() for k, v in body.queue_sources.items()},
+    )
+    return _serialize(state)
+
+
+class QueueInsertBody(BaseModel):
+    song_id: str
+    position: int | None = None
+    source: QueueSource | None = None
+
+
+class QueueReorderBody(BaseModel):
+    from_position: int
+    to_position: int
+
+
+@router.post("/queue", response_model=PlayerState)
+async def queue_insert(
+    body: QueueInsertBody,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    state = await crud.queue_insert(
+        db,
+        current_user.id,
+        body.song_id,
+        body.position,
+        body.source.model_dump() if body.source else None,
+    )
+    return _serialize(state)
+
+
+@router.delete("/queue/{song_id}", response_model=PlayerState)
+async def queue_remove(
+    song_id: str = Path(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    state = await crud.queue_remove(db, current_user.id, song_id)
+    return _serialize(state)
+
+
+@router.put("/queue/reorder", response_model=PlayerState)
+async def queue_reorder(
+    body: QueueReorderBody,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    state = await crud.queue_reorder(
+        db, current_user.id, body.from_position, body.to_position
     )
     return _serialize(state)

--- a/songbirdapi/routes.py
+++ b/songbirdapi/routes.py
@@ -86,6 +86,12 @@ def properties_path(song_id: str) -> str:
 
 # Player
 PLAYER_STATE = f"{V1}/player/state"
+PLAYER_QUEUE = f"{V1}/player/queue"
+PLAYER_QUEUE_REORDER = f"{V1}/player/queue/reorder"
+
+
+def player_queue_song_path(song_id: str) -> str:
+    return f"{PLAYER_QUEUE}/{song_id}"
 
 # Playlists
 PLAYLISTS = f"{V1}/playlists"

--- a/songbirdapi/routes.py
+++ b/songbirdapi/routes.py
@@ -1,0 +1,146 @@
+"""Canonical API route constants.
+
+Routers define sub-paths relative to their prefix; this module provides the
+full paths that clients and tests use.  One source of truth — update here
+when a path changes.
+"""
+
+V1 = "/v1"
+
+# Auth
+AUTH_LOGIN = f"{V1}/auth/login"
+AUTH_LOGOUT = f"{V1}/auth/logout"
+AUTH_ME = f"{V1}/auth/me"
+AUTH_PASSWORD = f"{V1}/auth/password"
+AUTH_REFRESH = f"{V1}/auth/refresh"
+AUTH_REGISTER = f"{V1}/auth/register"
+
+# Admin
+ADMIN_STATS = f"{V1}/admin/stats"
+ADMIN_ERRORS = f"{V1}/admin/errors"
+ADMIN_EDIT_JOBS = f"{V1}/admin/edit-jobs"
+ADMIN_USERS = f"{V1}/admin/users"
+
+
+def admin_user_path(user_id: str) -> str:
+    return f"{ADMIN_USERS}/{user_id}"
+
+
+# Library
+LIBRARY = f"{V1}/library"
+LIBRARY_BULK = f"{LIBRARY}/bulk"
+LIBRARY_OFFLINE = f"{LIBRARY}/offline"
+LIBRARY_PUBLISH = f"{LIBRARY}/publish"
+
+
+def library_song_path(song_id: str) -> str:
+    return f"{LIBRARY}/{song_id}"
+
+
+def library_position_path(song_id: str) -> str:
+    return f"{LIBRARY}/{song_id}/position"
+
+
+def library_offline_path(song_id: str) -> str:
+    return f"{LIBRARY}/offline/{song_id}"
+
+
+# Songs
+SONGS = f"{V1}/songs/"
+SONGS_LIBRARY = f"{V1}/songs/library"
+
+
+def song_path(song_id: str) -> str:
+    return f"{V1}/songs/{song_id}"
+
+
+def song_play_path(song_id: str) -> str:
+    return f"{V1}/songs/{song_id}/play"
+
+
+def song_artwork_path(song_id: str, size: str | int = "") -> str:
+    base = f"{V1}/songs/{song_id}/artwork"
+    return f"{base}/{size}" if size else base
+
+
+def songs_explore_path(window: str) -> str:
+    return f"{V1}/songs/explore?window={window}"
+
+
+# Download
+DOWNLOAD = f"{V1}/download"
+
+
+def download_path(song_id: str) -> str:
+    return f"{DOWNLOAD}/{song_id}"
+
+
+# Properties
+PROPERTIES = f"{V1}/properties"
+PROPERTIES_ITUNES = f"{V1}/properties/itunes"
+
+
+def properties_path(song_id: str) -> str:
+    return f"{PROPERTIES}/{song_id}"
+
+
+# Player
+PLAYER_STATE = f"{V1}/player/state"
+
+# Playlists
+PLAYLISTS = f"{V1}/playlists"
+
+
+def playlist_path(playlist_id: str) -> str:
+    return f"{PLAYLISTS}/{playlist_id}"
+
+
+def playlist_songs_path(playlist_id: str) -> str:
+    return f"{PLAYLISTS}/{playlist_id}/songs"
+
+
+def playlist_song_path(playlist_id: str, song_id: str) -> str:
+    return f"{PLAYLISTS}/{playlist_id}/songs/{song_id}"
+
+
+def playlist_songs_bulk_path(playlist_id: str) -> str:
+    return f"{PLAYLISTS}/{playlist_id}/songs/bulk"
+
+
+# Import
+IMPORT = f"{V1}/import"
+
+
+def import_job_path(job_id: str) -> str:
+    return f"{IMPORT}/{job_id}"
+
+
+# Edit
+def edit_song_path(song_id: str) -> str:
+    return f"{V1}/edit/songs/{song_id}"
+
+
+def edit_draft_path(song_id: str) -> str:
+    return f"{V1}/edit/songs/{song_id}/draft"
+
+
+def edit_job_path(job_id: str) -> str:
+    return f"{V1}/edit/jobs/{job_id}"
+
+
+# Share
+def share_song_path(song_id: str) -> str:
+    return f"{V1}/share/songs/{song_id}"
+
+
+def share_info_path(token: str) -> str:
+    return f"{V1}/share/{token}/info"
+
+
+def share_download_path(token: str) -> str:
+    return f"{V1}/share/{token}/download"
+
+
+# Health / Version
+HEALTH = f"{V1}/health"
+VERSION = f"{V1}/version"

--- a/songbirdapi/routes.py
+++ b/songbirdapi/routes.py
@@ -93,6 +93,7 @@ PLAYER_QUEUE_REORDER = f"{V1}/player/queue/reorder"
 def player_queue_song_path(song_id: str) -> str:
     return f"{PLAYER_QUEUE}/{song_id}"
 
+
 # Playlists
 PLAYLISTS = f"{V1}/playlists"
 

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.11"
+version = "v0.0.12"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -114,3 +114,17 @@ async def sample_song(test_client):
     yield song
     async with _TestingSession() as db:
         await crud.delete_song(db, song.uuid)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def second_song(test_client):
+    async with _TestingSession() as db:
+        song = Song(
+            uuid=str(uuid.uuid4()),
+            url="https://example.com/test-song-2",
+            file_path="/tmp/test-song-2.mp3",
+        )
+        await crud.insert_song(db, song)
+    yield song
+    async with _TestingSession() as db:
+        await crud.delete_song(db, song.uuid)

--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -1,19 +1,20 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import ADMIN_EDIT_JOBS, ADMIN_ERRORS, ADMIN_STATS, ADMIN_USERS, AUTH_LOGIN, AUTH_REGISTER, admin_user_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
 
 async def test_stats_as_admin(test_client: AsyncClient, admin_user):
     cookies = await login(test_client, admin_user)
-    resp = await test_client.get("/v1/admin/stats", cookies=cookies)
+    resp = await test_client.get(ADMIN_STATS, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "song_count" in body
@@ -24,13 +25,13 @@ async def test_stats_as_admin(test_client: AsyncClient, admin_user):
 
 async def test_stats_as_regular_user_forbidden(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/admin/stats", cookies=cookies)
+    resp = await test_client.get(ADMIN_STATS, cookies=cookies)
     assert resp.status_code == 403
 
 
 async def test_errors_as_admin(test_client: AsyncClient, admin_user):
     cookies = await login(test_client, admin_user)
-    resp = await test_client.get("/v1/admin/errors", cookies=cookies)
+    resp = await test_client.get(ADMIN_ERRORS, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "total" in body
@@ -40,7 +41,7 @@ async def test_errors_as_admin(test_client: AsyncClient, admin_user):
 
 async def test_errors_as_regular_user_forbidden(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/admin/errors", cookies=cookies)
+    resp = await test_client.get(ADMIN_ERRORS, cookies=cookies)
     assert resp.status_code == 403
 
 
@@ -48,7 +49,7 @@ async def test_update_user_as_admin(test_client: AsyncClient, admin_user, regula
     cookies = await login(test_client, admin_user)
 
     resp = await test_client.patch(
-        f"/v1/admin/users/{regular_user.id}",
+        admin_user_path(regular_user.id),
         json={"is_active": False},
         cookies=cookies,
     )
@@ -56,7 +57,7 @@ async def test_update_user_as_admin(test_client: AsyncClient, admin_user, regula
     assert resp.json()["is_active"] is False
 
     restore = await test_client.patch(
-        f"/v1/admin/users/{regular_user.id}",
+        admin_user_path(regular_user.id),
         json={"is_active": True},
         cookies=cookies,
     )
@@ -66,7 +67,7 @@ async def test_update_user_as_admin(test_client: AsyncClient, admin_user, regula
 
 async def test_list_users_as_admin(test_client: AsyncClient, admin_user, regular_user):
     cookies = await login(test_client, admin_user)
-    resp = await test_client.get("/v1/admin/users", cookies=cookies)
+    resp = await test_client.get(ADMIN_USERS, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert isinstance(body, list)
@@ -77,14 +78,14 @@ async def test_list_users_as_regular_user_forbidden(
     test_client: AsyncClient, regular_user
 ):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/admin/users", cookies=cookies)
+    resp = await test_client.get(ADMIN_USERS, cookies=cookies)
     assert resp.status_code == 403
 
 
 async def test_update_user_not_found(test_client: AsyncClient, admin_user):
     cookies = await login(test_client, admin_user)
     resp = await test_client.patch(
-        "/v1/admin/users/00000000-0000-0000-0000-000000000000",
+        admin_user_path("00000000-0000-0000-0000-000000000000"),
         json={"is_active": True},
         cookies=cookies,
     )
@@ -96,7 +97,7 @@ async def test_update_user_role_as_admin(
 ):
     cookies = await login(test_client, admin_user)
     resp = await test_client.patch(
-        f"/v1/admin/users/{regular_user.id}",
+        admin_user_path(regular_user.id),
         json={"role": "user"},
         cookies=cookies,
     )
@@ -108,12 +109,12 @@ async def test_delete_user_as_admin(test_client: AsyncClient, admin_user):
     import uuid
 
     admin_login = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": admin_user.username, "password": "testpass123"},
     )
     uname = f"todelete_{uuid.uuid4().hex[:6]}"
     reg = await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={"username": uname, "email": f"{uname}@test.com", "password": "pass123"},
         cookies=admin_login.cookies,
     )
@@ -121,27 +122,27 @@ async def test_delete_user_as_admin(test_client: AsyncClient, admin_user):
     user_id = reg.json()["id"]
 
     cookies = await login(test_client, admin_user)
-    resp = await test_client.delete(f"/v1/admin/users/{user_id}", cookies=cookies)
+    resp = await test_client.delete(admin_user_path(user_id), cookies=cookies)
     assert resp.status_code == 204
 
 
 async def test_delete_user_not_found(test_client: AsyncClient, admin_user):
     cookies = await login(test_client, admin_user)
     resp = await test_client.delete(
-        "/v1/admin/users/00000000-0000-0000-0000-000000000000", cookies=cookies
+        admin_user_path("00000000-0000-0000-0000-000000000000"), cookies=cookies
     )
     assert resp.status_code == 404
 
 
 async def test_delete_user_requires_admin(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.delete("/v1/admin/users/some-id", cookies=cookies)
+    resp = await test_client.delete(admin_user_path("some-id"), cookies=cookies)
     assert resp.status_code == 403
 
 
 async def test_get_edit_jobs_as_admin(test_client: AsyncClient, admin_user):
     cookies = await login(test_client, admin_user)
-    resp = await test_client.get("/v1/admin/edit-jobs", cookies=cookies)
+    resp = await test_client.get(ADMIN_EDIT_JOBS, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "total" in body
@@ -151,23 +152,23 @@ async def test_get_edit_jobs_as_admin(test_client: AsyncClient, admin_user):
 
 async def test_get_edit_jobs_requires_admin(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/admin/edit-jobs", cookies=cookies)
+    resp = await test_client.get(ADMIN_EDIT_JOBS, cookies=cookies)
     assert resp.status_code == 403
 
 
 async def test_get_edit_jobs_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/admin/edit-jobs")
+    resp = await test_client.get(ADMIN_EDIT_JOBS)
     assert resp.status_code == 401
 
 
 async def test_stats_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/admin/stats")
+    resp = await test_client.get(ADMIN_STATS)
     assert resp.status_code == 401
 
 
 async def test_stats_has_extended_fields(test_client: AsyncClient, admin_user):
     cookies = await login(test_client, admin_user)
-    resp = await test_client.get("/v1/admin/stats", cookies=cookies)
+    resp = await test_client.get(ADMIN_STATS, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "plays_by_day" in body

--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -1,6 +1,14 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import ADMIN_EDIT_JOBS, ADMIN_ERRORS, ADMIN_STATS, ADMIN_USERS, AUTH_LOGIN, AUTH_REGISTER, admin_user_path
+from songbirdapi.routes import (
+    ADMIN_EDIT_JOBS,
+    ADMIN_ERRORS,
+    ADMIN_STATS,
+    ADMIN_USERS,
+    AUTH_LOGIN,
+    AUTH_REGISTER,
+    admin_user_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,6 +1,15 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import AUTH_LOGIN, AUTH_LOGOUT, AUTH_ME, AUTH_PASSWORD, AUTH_REFRESH, AUTH_REGISTER, admin_user_path, properties_path
+from songbirdapi.routes import (
+    AUTH_LOGIN,
+    AUTH_LOGOUT,
+    AUTH_ME,
+    AUTH_PASSWORD,
+    AUTH_REFRESH,
+    AUTH_REGISTER,
+    admin_user_path,
+    properties_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,5 +1,6 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, AUTH_LOGOUT, AUTH_ME, AUTH_PASSWORD, AUTH_REFRESH, AUTH_REGISTER, admin_user_path, properties_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -9,12 +10,12 @@ async def test_root_is_public(test_client: AsyncClient):
 
 
 async def test_protected_route_requires_auth(test_client: AsyncClient):
-    assert (await test_client.get("/v1/properties/nonexistent-id")).status_code == 401
+    assert (await test_client.get(properties_path("nonexistent-id"))).status_code == 401
 
 
 async def test_login_success(test_client: AsyncClient, admin_user):
     resp = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": admin_user.username, "password": "testpass123"},
     )
     assert resp.status_code == 200
@@ -27,45 +28,45 @@ async def test_login_success(test_client: AsyncClient, admin_user):
 
 async def test_login_wrong_password(test_client: AsyncClient, admin_user):
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": admin_user.username, "password": "wrong"}
+        AUTH_LOGIN, json={"username": admin_user.username, "password": "wrong"}
     )
     assert resp.status_code == 401
 
 
 async def test_login_unknown_user(test_client: AsyncClient):
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": "nobody", "password": "pass"}
+        AUTH_LOGIN, json={"username": "nobody", "password": "pass"}
     )
     assert resp.status_code == 401
 
 
 async def test_me_returns_current_user(test_client: AsyncClient, regular_user):
     login = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": regular_user.username, "password": "testpass123"},
     )
-    resp = await test_client.get("/v1/auth/me", cookies=login.cookies)
+    resp = await test_client.get(AUTH_ME, cookies=login.cookies)
     assert resp.status_code == 200
     assert resp.json()["username"] == regular_user.username
 
 
 async def test_logout_clears_cookies(test_client: AsyncClient, admin_user):
     login = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": admin_user.username, "password": "testpass123"},
     )
-    resp = await test_client.post("/v1/auth/logout", cookies=login.cookies)
+    resp = await test_client.post(AUTH_LOGOUT, cookies=login.cookies)
     assert resp.status_code == 200
     assert resp.cookies.get("access_token", "") == ""
 
 
 async def test_register_requires_admin(test_client: AsyncClient, regular_user):
     login = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": regular_user.username, "password": "testpass123"},
     )
     resp = await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={"username": "newuser", "email": "new@test.com", "password": "pass123"},
         cookies=login.cookies,
     )
@@ -77,11 +78,11 @@ async def test_register_as_admin(test_client: AsyncClient, admin_user):
 
     username = f"newuser_{uuid.uuid4().hex[:6]}"
     login = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": admin_user.username, "password": "testpass123"},
     )
     resp = await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={
             "username": username,
             "email": f"{username}@test.com",
@@ -95,21 +96,21 @@ async def test_register_as_admin(test_client: AsyncClient, admin_user):
 
 async def test_token_refresh(test_client: AsyncClient, regular_user):
     login = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": regular_user.username, "password": "testpass123"},
     )
-    resp = await test_client.post("/v1/auth/refresh", cookies=login.cookies)
+    resp = await test_client.post(AUTH_REFRESH, cookies=login.cookies)
     assert resp.status_code == 200
     assert "access_token" in resp.cookies
 
 
 async def test_refresh_without_cookie_fails(test_client: AsyncClient):
-    resp = await test_client.post("/v1/auth/refresh")
+    resp = await test_client.post(AUTH_REFRESH)
     assert resp.status_code == 401
 
 
 async def test_me_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/auth/me")
+    resp = await test_client.get(AUTH_ME)
     assert resp.status_code == 401
 
 
@@ -117,19 +118,19 @@ async def test_register_duplicate_username(test_client: AsyncClient, admin_user)
     import uuid
 
     login_resp = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": admin_user.username, "password": "testpass123"},
     )
     # register a new user
     unique = uuid.uuid4().hex[:8]
     await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={"username": unique, "email": f"{unique}@test.com", "password": "pass"},
         cookies=login_resp.cookies,
     )
     # try registering same username again
     resp = await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={
             "username": unique,
             "email": f"other_{unique}@test.com",
@@ -144,17 +145,17 @@ async def test_register_duplicate_email(test_client: AsyncClient, admin_user):
     import uuid
 
     login_resp = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": admin_user.username, "password": "testpass123"},
     )
     unique = uuid.uuid4().hex[:8]
     await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={"username": unique, "email": f"{unique}@test.com", "password": "pass"},
         cookies=login_resp.cookies,
     )
     resp = await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={
             "username": f"other_{unique}",
             "email": f"{unique}@test.com",
@@ -167,7 +168,7 @@ async def test_register_duplicate_email(test_client: AsyncClient, admin_user):
 
 async def test_register_without_auth(test_client: AsyncClient):
     resp = await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={"username": "anon", "email": "anon@test.com", "password": "pass"},
     )
     assert resp.status_code == 401
@@ -178,22 +179,22 @@ async def test_change_password(test_client: AsyncClient, admin_user):
 
     # register a throwaway user to change password on
     admin_login = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": admin_user.username, "password": "testpass123"},
     )
     uname = f"pwchange_{uuid.uuid4().hex[:6]}"
     await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={"username": uname, "email": f"{uname}@test.com", "password": "oldpass"},
         cookies=admin_login.cookies,
     )
     user_login = await test_client.post(
-        "/v1/auth/login", json={"username": uname, "password": "oldpass"}
+        AUTH_LOGIN, json={"username": uname, "password": "oldpass"}
     )
     assert user_login.status_code == 200
 
     resp = await test_client.patch(
-        "/v1/auth/password",
+        AUTH_PASSWORD,
         json={"current_password": "oldpass", "new_password": "newpass"},
         cookies=user_login.cookies,
     )
@@ -201,24 +202,24 @@ async def test_change_password(test_client: AsyncClient, admin_user):
 
     # old password should no longer work
     old_login = await test_client.post(
-        "/v1/auth/login", json={"username": uname, "password": "oldpass"}
+        AUTH_LOGIN, json={"username": uname, "password": "oldpass"}
     )
     assert old_login.status_code == 401
 
     # new password should work
     new_login = await test_client.post(
-        "/v1/auth/login", json={"username": uname, "password": "newpass"}
+        AUTH_LOGIN, json={"username": uname, "password": "newpass"}
     )
     assert new_login.status_code == 200
 
 
 async def test_change_password_wrong_current(test_client: AsyncClient, regular_user):
     login_resp = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": regular_user.username, "password": "testpass123"},
     )
     resp = await test_client.patch(
-        "/v1/auth/password",
+        AUTH_PASSWORD,
         json={"current_password": "wrongpassword", "new_password": "newpass"},
         cookies=login_resp.cookies,
     )
@@ -227,7 +228,7 @@ async def test_change_password_wrong_current(test_client: AsyncClient, regular_u
 
 async def test_change_password_requires_auth(test_client: AsyncClient):
     resp = await test_client.patch(
-        "/v1/auth/password",
+        AUTH_PASSWORD,
         json={"current_password": "x", "new_password": "y"},
     )
     assert resp.status_code == 401
@@ -237,12 +238,12 @@ async def test_disabled_user_cannot_login(test_client: AsyncClient, admin_user):
     import uuid
 
     admin_login = await test_client.post(
-        "/v1/auth/login",
+        AUTH_LOGIN,
         json={"username": admin_user.username, "password": "testpass123"},
     )
     uname = f"disabled_{uuid.uuid4().hex[:6]}"
     reg = await test_client.post(
-        "/v1/auth/register",
+        AUTH_REGISTER,
         json={"username": uname, "email": f"{uname}@test.com", "password": "pass123"},
         cookies=admin_login.cookies,
     )
@@ -251,12 +252,12 @@ async def test_disabled_user_cannot_login(test_client: AsyncClient, admin_user):
 
     # disable the user
     await test_client.patch(
-        f"/v1/admin/users/{user_id}",
+        admin_user_path(user_id),
         json={"is_active": False},
         cookies=admin_login.cookies,
     )
 
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": uname, "password": "pass123"}
+        AUTH_LOGIN, json={"username": uname, "password": "pass123"}
     )
     assert resp.status_code == 403

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -1,12 +1,13 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, DOWNLOAD, download_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
@@ -18,18 +19,18 @@ async def login(test_client: AsyncClient, user) -> dict:
 
 async def test_download_post_requires_auth(test_client: AsyncClient):
     resp = await test_client.post(
-        "/v1/download", json={"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}
+        DOWNLOAD, json={"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}
     )
     assert resp.status_code == 401
 
 
 async def test_get_download_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/download/nonexistent-id")
+    resp = await test_client.get(download_path("nonexistent-id"))
     assert resp.status_code == 401
 
 
 async def test_delete_download_requires_auth(test_client: AsyncClient):
-    resp = await test_client.delete("/v1/download/nonexistent-id")
+    resp = await test_client.delete(download_path("nonexistent-id"))
     assert resp.status_code == 401
 
 
@@ -41,7 +42,7 @@ async def test_delete_download_requires_auth(test_client: AsyncClient):
 async def test_get_download_not_found(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.get(
-        "/v1/download/00000000-0000-0000-0000-000000000000", cookies=cookies
+        download_path("00000000-0000-0000-0000-000000000000"), cookies=cookies
     )
     assert resp.status_code == 404
 
@@ -56,7 +57,7 @@ async def test_delete_download_nonexistent_is_ok(
 ):
     cookies = await login(test_client, regular_user)
     resp = await test_client.delete(
-        "/v1/download/00000000-0000-0000-0000-000000000000", cookies=cookies
+        download_path("00000000-0000-0000-0000-000000000000"), cookies=cookies
     )
     # router does not raise on missing — just deletes nothing
     assert resp.status_code in (200, 204)
@@ -72,7 +73,7 @@ async def test_download_cached_returns_existing_song(
 ):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        "/v1/download",
+        DOWNLOAD,
         json={"url": sample_song.url, "ignore_cache": False},
         cookies=cookies,
     )

--- a/tests/integration/test_edit.py
+++ b/tests/integration/test_edit.py
@@ -1,6 +1,12 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import AUTH_LOGIN, edit_draft_path, edit_job_path, edit_song_path, song_path
+from songbirdapi.routes import (
+    AUTH_LOGIN,
+    edit_draft_path,
+    edit_job_path,
+    edit_song_path,
+    song_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -35,9 +41,7 @@ async def test_get_draft(test_client: AsyncClient, regular_user, sample_song):
     await test_client.put(
         edit_draft_path(sample_song.uuid), json=_EDIT_PARAMS, cookies=cookies
     )
-    resp = await test_client.get(
-        edit_draft_path(sample_song.uuid), cookies=cookies
-    )
+    resp = await test_client.get(edit_draft_path(sample_song.uuid), cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert body["params"]["trim_start"] == 0
@@ -50,9 +54,7 @@ async def test_delete_draft(test_client: AsyncClient, regular_user, sample_song)
     await test_client.put(
         edit_draft_path(sample_song.uuid), json=_EDIT_PARAMS, cookies=cookies
     )
-    resp = await test_client.delete(
-        edit_draft_path(sample_song.uuid), cookies=cookies
-    )
+    resp = await test_client.delete(edit_draft_path(sample_song.uuid), cookies=cookies)
     assert resp.status_code == 204
 
 
@@ -63,12 +65,8 @@ async def test_get_draft_after_delete_returns_404(
     await test_client.put(
         edit_draft_path(sample_song.uuid), json=_EDIT_PARAMS, cookies=cookies
     )
-    await test_client.delete(
-        edit_draft_path(sample_song.uuid), cookies=cookies
-    )
-    resp = await test_client.get(
-        edit_draft_path(sample_song.uuid), cookies=cookies
-    )
+    await test_client.delete(edit_draft_path(sample_song.uuid), cookies=cookies)
+    resp = await test_client.get(edit_draft_path(sample_song.uuid), cookies=cookies)
     assert resp.status_code == 404
 
 

--- a/tests/integration/test_edit.py
+++ b/tests/integration/test_edit.py
@@ -1,5 +1,6 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, edit_draft_path, edit_job_path, edit_song_path, song_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -16,7 +17,7 @@ _EDIT_PARAMS = {
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
@@ -24,7 +25,7 @@ async def login(test_client: AsyncClient, user) -> dict:
 async def test_save_draft(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     resp = await test_client.put(
-        f"/v1/edit/songs/{sample_song.uuid}/draft", json=_EDIT_PARAMS, cookies=cookies
+        edit_draft_path(sample_song.uuid), json=_EDIT_PARAMS, cookies=cookies
     )
     assert resp.status_code in (200, 204)
 
@@ -32,10 +33,10 @@ async def test_save_draft(test_client: AsyncClient, regular_user, sample_song):
 async def test_get_draft(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     await test_client.put(
-        f"/v1/edit/songs/{sample_song.uuid}/draft", json=_EDIT_PARAMS, cookies=cookies
+        edit_draft_path(sample_song.uuid), json=_EDIT_PARAMS, cookies=cookies
     )
     resp = await test_client.get(
-        f"/v1/edit/songs/{sample_song.uuid}/draft", cookies=cookies
+        edit_draft_path(sample_song.uuid), cookies=cookies
     )
     assert resp.status_code == 200
     body = resp.json()
@@ -47,10 +48,10 @@ async def test_get_draft(test_client: AsyncClient, regular_user, sample_song):
 async def test_delete_draft(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     await test_client.put(
-        f"/v1/edit/songs/{sample_song.uuid}/draft", json=_EDIT_PARAMS, cookies=cookies
+        edit_draft_path(sample_song.uuid), json=_EDIT_PARAMS, cookies=cookies
     )
     resp = await test_client.delete(
-        f"/v1/edit/songs/{sample_song.uuid}/draft", cookies=cookies
+        edit_draft_path(sample_song.uuid), cookies=cookies
     )
     assert resp.status_code == 204
 
@@ -60,13 +61,13 @@ async def test_get_draft_after_delete_returns_404(
 ):
     cookies = await login(test_client, regular_user)
     await test_client.put(
-        f"/v1/edit/songs/{sample_song.uuid}/draft", json=_EDIT_PARAMS, cookies=cookies
+        edit_draft_path(sample_song.uuid), json=_EDIT_PARAMS, cookies=cookies
     )
     await test_client.delete(
-        f"/v1/edit/songs/{sample_song.uuid}/draft", cookies=cookies
+        edit_draft_path(sample_song.uuid), cookies=cookies
     )
     resp = await test_client.get(
-        f"/v1/edit/songs/{sample_song.uuid}/draft", cookies=cookies
+        edit_draft_path(sample_song.uuid), cookies=cookies
     )
     assert resp.status_code == 404
 
@@ -74,7 +75,7 @@ async def test_get_draft_after_delete_returns_404(
 async def test_create_edit_job(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        f"/v1/edit/songs/{sample_song.uuid}",
+        edit_song_path(sample_song.uuid),
         json={"params": _EDIT_PARAMS, "overwrite": False},
         cookies=cookies,
     )
@@ -87,11 +88,11 @@ async def test_create_edit_job(test_client: AsyncClient, regular_user, sample_so
 async def test_get_edit_job(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     create_resp = await test_client.post(
-        f"/v1/edit/songs/{sample_song.uuid}",
+        edit_song_path(sample_song.uuid),
         json={"params": _EDIT_PARAMS, "overwrite": False},
         cookies=cookies,
     )
     job_id = create_resp.json()["job_id"]
-    resp = await test_client.get(f"/v1/edit/jobs/{job_id}", cookies=cookies)
+    resp = await test_client.get(edit_job_path(job_id), cookies=cookies)
     assert resp.status_code == 200
     assert "status" in resp.json()

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -1,5 +1,6 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, IMPORT, import_job_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -12,14 +13,14 @@ MINIMAL_MP3 = (
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
 
 async def test_start_import_requires_auth(test_client: AsyncClient):
     resp = await test_client.post(
-        "/v1/import", files={"file": ("song.mp3", MINIMAL_MP3, "audio/mpeg")}
+        IMPORT, files={"file": ("song.mp3", MINIMAL_MP3, "audio/mpeg")}
     )
     assert resp.status_code == 401
 
@@ -27,7 +28,7 @@ async def test_start_import_requires_auth(test_client: AsyncClient):
 async def test_start_import_invalid_file_type(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        "/v1/import",
+        IMPORT,
         files={"file": ("notes.txt", b"hello", "text/plain")},
         cookies=cookies,
     )
@@ -37,7 +38,7 @@ async def test_start_import_invalid_file_type(test_client: AsyncClient, regular_
 async def test_start_import_valid_mp3(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        "/v1/import",
+        IMPORT,
         files={"file": ("song.mp3", MINIMAL_MP3, "audio/mpeg")},
         cookies=cookies,
     )
@@ -48,13 +49,13 @@ async def test_start_import_valid_mp3(test_client: AsyncClient, regular_user):
 
 
 async def test_list_imports_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/import")
+    resp = await test_client.get(IMPORT)
     assert resp.status_code == 401
 
 
 async def test_list_imports_empty(test_client: AsyncClient, admin_user):
     cookies = await login(test_client, admin_user)
-    resp = await test_client.get("/v1/import", cookies=cookies)
+    resp = await test_client.get(IMPORT, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "total" in body
@@ -65,14 +66,14 @@ async def test_list_imports_empty(test_client: AsyncClient, admin_user):
 async def test_list_imports_after_upload(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     post = await test_client.post(
-        "/v1/import",
+        IMPORT,
         files={"file": ("track.mp3", MINIMAL_MP3, "audio/mpeg")},
         cookies=cookies,
     )
     assert post.status_code == 202
     job_id = post.json()["job_id"]
 
-    resp = await test_client.get("/v1/import", cookies=cookies)
+    resp = await test_client.get(IMPORT, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "total" in body
@@ -81,27 +82,27 @@ async def test_list_imports_after_upload(test_client: AsyncClient, regular_user)
 
 
 async def test_get_import_job_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/import/some-job-id")
+    resp = await test_client.get(import_job_path("some-job-id"))
     assert resp.status_code == 401
 
 
 async def test_get_import_job_not_found(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/import/nonexistent-job-id", cookies=cookies)
+    resp = await test_client.get(import_job_path("nonexistent-job-id"), cookies=cookies)
     assert resp.status_code == 404
 
 
 async def test_get_import_job_found(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     post = await test_client.post(
-        "/v1/import",
+        IMPORT,
         files={"file": ("album.mp3", MINIMAL_MP3, "audio/mpeg")},
         cookies=cookies,
     )
     assert post.status_code == 202
     job_id = post.json()["job_id"]
 
-    resp = await test_client.get(f"/v1/import/{job_id}", cookies=cookies)
+    resp = await test_client.get(import_job_path(job_id), cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert body["job_id"] == job_id
@@ -111,7 +112,7 @@ async def test_get_import_job_found(test_client: AsyncClient, regular_user):
 async def test_start_import_valid_m4a(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        "/v1/import",
+        IMPORT,
         files={"file": ("song.m4a", MINIMAL_MP3, "audio/mp4")},
         cookies=cookies,
     )
@@ -122,7 +123,7 @@ async def test_start_import_valid_m4a(test_client: AsyncClient, regular_user):
 
 async def test_list_imports_pagination(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/import?limit=1&offset=0", cookies=cookies)
+    resp = await test_client.get(f"{IMPORT}?limit=1&offset=0", cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "total" in body
@@ -135,7 +136,7 @@ async def test_import_job_not_visible_to_other_user(
 ):
     reg_cookies = await login(test_client, regular_user)
     post = await test_client.post(
-        "/v1/import",
+        IMPORT,
         files={"file": ("private.mp3", MINIMAL_MP3, "audio/mpeg")},
         cookies=reg_cookies,
     )
@@ -143,5 +144,5 @@ async def test_import_job_not_visible_to_other_user(
     job_id = post.json()["job_id"]
 
     adm_cookies = await login(test_client, admin_user)
-    resp = await test_client.get(f"/v1/import/{job_id}", cookies=adm_cookies)
+    resp = await test_client.get(import_job_path(job_id), cookies=adm_cookies)
     assert resp.status_code == 404

--- a/tests/integration/test_library.py
+++ b/tests/integration/test_library.py
@@ -62,6 +62,20 @@ async def test_remove_from_library(test_client: AsyncClient, regular_user, sampl
     assert not any(e["song_id"] == sample_song.uuid for e in resp.json())
 
 
+async def test_remove_from_library_cleans_offline(
+    test_client: AsyncClient, regular_user, sample_song
+):
+    cookies = await login(test_client, regular_user)
+    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    await test_client.post(f"/v1/library/offline/{sample_song.uuid}", cookies=cookies)
+    resp = await test_client.get("/v1/library/offline", cookies=cookies)
+    assert sample_song.uuid in resp.json()
+
+    await test_client.delete(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    resp = await test_client.get("/v1/library/offline", cookies=cookies)
+    assert sample_song.uuid not in resp.json()
+
+
 async def test_remove_nonexistent_returns_404(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.delete("/v1/library/does-not-exist", cookies=cookies)
@@ -186,6 +200,45 @@ async def test_bulk_remove_from_library(
     assert sample_song.uuid not in uuids
     assert second_uuid not in uuids
     # cleanup
+    async with _TestingSession() as db:
+        await _crud.delete_song(db, second_uuid)
+
+
+async def test_bulk_remove_cleans_offline(
+    test_client: AsyncClient, regular_user, sample_song
+):
+    import uuid as _uuid
+
+    from songbirdapi import crud as _crud
+    from songbirdapi.models import Song as _Song
+    from tests.integration.conftest import _TestingSession
+
+    cookies = await login(test_client, regular_user)
+    second_uuid = str(_uuid.uuid4())
+    async with _TestingSession() as db:
+        song2 = _Song(
+            uuid=second_uuid,
+            url="https://example.com/bulk-offline-song2",
+            file_path="/tmp/bulk-offline-song2.mp3",
+        )
+        await _crud.insert_song(db, song2)
+    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    await test_client.post(f"/v1/library/{second_uuid}", cookies=cookies)
+    await test_client.post(f"/v1/library/offline/{sample_song.uuid}", cookies=cookies)
+    await test_client.post(f"/v1/library/offline/{second_uuid}", cookies=cookies)
+
+    resp = await test_client.request(
+        "DELETE",
+        "/v1/library/bulk",
+        json={"song_ids": [sample_song.uuid, second_uuid]},
+        cookies=cookies,
+    )
+    assert resp.status_code == 204
+    resp = await test_client.get("/v1/library/offline", cookies=cookies)
+    offline_ids = resp.json()
+    assert sample_song.uuid not in offline_ids
+    assert second_uuid not in offline_ids
+
     async with _TestingSession() as db:
         await _crud.delete_song(db, second_uuid)
 

--- a/tests/integration/test_library.py
+++ b/tests/integration/test_library.py
@@ -1,26 +1,27 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, LIBRARY, LIBRARY_BULK, LIBRARY_OFFLINE, LIBRARY_PUBLISH, library_offline_path, library_position_path, library_song_path, song_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
 
 async def test_library_empty_on_start(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/library", cookies=cookies)
+    resp = await test_client.get(LIBRARY, cookies=cookies)
     assert resp.status_code == 200
     assert resp.json() == []
 
 
 async def test_add_to_library(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    resp = await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
     assert resp.status_code == 201
     body = resp.json()
     assert body["song_id"] == sample_song.uuid
@@ -32,14 +33,14 @@ async def test_add_to_library_idempotent(
     test_client: AsyncClient, regular_user, sample_song
 ):
     cookies = await login(test_client, regular_user)
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    resp = await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    resp = await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
     assert resp.status_code == 201
 
 
 async def test_add_nonexistent_song_returns_404(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.post("/v1/library/does-not-exist", cookies=cookies)
+    resp = await test_client.post(library_song_path("does-not-exist"), cookies=cookies)
     assert resp.status_code == 404
 
 
@@ -47,18 +48,18 @@ async def test_library_contains_added_song(
     test_client: AsyncClient, regular_user, sample_song
 ):
     cookies = await login(test_client, regular_user)
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    resp = await test_client.get("/v1/library", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    resp = await test_client.get(LIBRARY, cookies=cookies)
     assert resp.status_code == 200
     assert any(e["song_id"] == sample_song.uuid for e in resp.json())
 
 
 async def test_remove_from_library(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    resp = await test_client.delete(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    resp = await test_client.delete(library_song_path(sample_song.uuid), cookies=cookies)
     assert resp.status_code == 204
-    resp = await test_client.get("/v1/library", cookies=cookies)
+    resp = await test_client.get(LIBRARY, cookies=cookies)
     assert not any(e["song_id"] == sample_song.uuid for e in resp.json())
 
 
@@ -66,27 +67,27 @@ async def test_remove_from_library_cleans_offline(
     test_client: AsyncClient, regular_user, sample_song
 ):
     cookies = await login(test_client, regular_user)
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    await test_client.post(f"/v1/library/offline/{sample_song.uuid}", cookies=cookies)
-    resp = await test_client.get("/v1/library/offline", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    await test_client.post(library_offline_path(sample_song.uuid), cookies=cookies)
+    resp = await test_client.get(LIBRARY_OFFLINE, cookies=cookies)
     assert sample_song.uuid in resp.json()
 
-    await test_client.delete(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    resp = await test_client.get("/v1/library/offline", cookies=cookies)
+    await test_client.delete(library_song_path(sample_song.uuid), cookies=cookies)
+    resp = await test_client.get(LIBRARY_OFFLINE, cookies=cookies)
     assert sample_song.uuid not in resp.json()
 
 
 async def test_remove_nonexistent_returns_404(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.delete("/v1/library/does-not-exist", cookies=cookies)
+    resp = await test_client.delete(library_song_path("does-not-exist"), cookies=cookies)
     assert resp.status_code == 404
 
 
 async def test_update_position(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
     resp = await test_client.patch(
-        f"/v1/library/{sample_song.uuid}/position",
+        library_position_path(sample_song.uuid),
         json={"position": 42.5},
         cookies=cookies,
     )
@@ -105,7 +106,7 @@ async def test_update_position_not_in_library_returns_404(
 ):
     cookies = await login(test_client, regular_user)
     resp = await test_client.patch(
-        "/v1/library/00000000-0000-0000-0000-000000000000/position",
+        library_position_path("00000000-0000-0000-0000-000000000000"),
         json={"position": 10.0},
         cookies=cookies,
     )
@@ -118,23 +119,23 @@ async def test_update_position_not_in_library_returns_404(
 
 
 async def test_get_library_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/library")
+    resp = await test_client.get(LIBRARY)
     assert resp.status_code == 401
 
 
 async def test_add_to_library_requires_auth(test_client: AsyncClient, sample_song):
-    resp = await test_client.post(f"/v1/library/{sample_song.uuid}")
+    resp = await test_client.post(library_song_path(sample_song.uuid))
     assert resp.status_code == 401
 
 
 async def test_remove_from_library_requires_auth(test_client: AsyncClient, sample_song):
-    resp = await test_client.delete(f"/v1/library/{sample_song.uuid}")
+    resp = await test_client.delete(library_song_path(sample_song.uuid))
     assert resp.status_code == 401
 
 
 async def test_update_position_requires_auth(test_client: AsyncClient, sample_song):
     resp = await test_client.patch(
-        f"/v1/library/{sample_song.uuid}/position", json={"position": 0.0}
+        library_position_path(sample_song.uuid), json={"position": 0.0}
     )
     assert resp.status_code == 401
 
@@ -145,14 +146,14 @@ async def test_update_position_requires_auth(test_client: AsyncClient, sample_so
 
 
 async def test_publish_requires_auth(test_client: AsyncClient):
-    resp = await test_client.post("/v1/library/publish")
+    resp = await test_client.post(LIBRARY_PUBLISH)
     assert resp.status_code == 401
 
 
 async def test_publish_returns_count(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        "/v1/library/publish", json={"song_ids": []}, cookies=cookies
+        LIBRARY_PUBLISH, json={"song_ids": []}, cookies=cookies
     )
     assert resp.status_code == 200
     body = resp.json()
@@ -185,17 +186,17 @@ async def test_bulk_remove_from_library(
         )
         await _crud.insert_song(db, song2)
     # add both to library
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    await test_client.post(f"/v1/library/{second_uuid}", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    await test_client.post(library_song_path(second_uuid), cookies=cookies)
     # bulk remove both
     resp = await test_client.request(
         "DELETE",
-        "/v1/library/bulk",
+        LIBRARY_BULK,
         json={"song_ids": [sample_song.uuid, second_uuid]},
         cookies=cookies,
     )
     assert resp.status_code == 204
-    lib = await test_client.get("/v1/library", cookies=cookies)
+    lib = await test_client.get(LIBRARY, cookies=cookies)
     uuids = [e["song_id"] for e in lib.json()]
     assert sample_song.uuid not in uuids
     assert second_uuid not in uuids
@@ -222,19 +223,19 @@ async def test_bulk_remove_cleans_offline(
             file_path="/tmp/bulk-offline-song2.mp3",
         )
         await _crud.insert_song(db, song2)
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    await test_client.post(f"/v1/library/{second_uuid}", cookies=cookies)
-    await test_client.post(f"/v1/library/offline/{sample_song.uuid}", cookies=cookies)
-    await test_client.post(f"/v1/library/offline/{second_uuid}", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    await test_client.post(library_song_path(second_uuid), cookies=cookies)
+    await test_client.post(library_offline_path(sample_song.uuid), cookies=cookies)
+    await test_client.post(library_offline_path(second_uuid), cookies=cookies)
 
     resp = await test_client.request(
         "DELETE",
-        "/v1/library/bulk",
+        LIBRARY_BULK,
         json={"song_ids": [sample_song.uuid, second_uuid]},
         cookies=cookies,
     )
     assert resp.status_code == 204
-    resp = await test_client.get("/v1/library/offline", cookies=cookies)
+    resp = await test_client.get(LIBRARY_OFFLINE, cookies=cookies)
     offline_ids = resp.json()
     assert sample_song.uuid not in offline_ids
     assert second_uuid not in offline_ids
@@ -259,24 +260,24 @@ async def test_bulk_remove_partial(test_client: AsyncClient, regular_user, sampl
             file_path="/tmp/bulk-song3.mp3",
         )
         await _crud.insert_song(db, song3)
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    await test_client.post(f"/v1/library/{third_uuid}", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    await test_client.post(library_song_path(third_uuid), cookies=cookies)
     # bulk remove only third
     resp = await test_client.request(
         "DELETE",
-        "/v1/library/bulk",
+        LIBRARY_BULK,
         json={"song_ids": [third_uuid]},
         cookies=cookies,
     )
     assert resp.status_code == 204
-    lib = await test_client.get("/v1/library", cookies=cookies)
+    lib = await test_client.get(LIBRARY, cookies=cookies)
     uuids = [e["song_id"] for e in lib.json()]
     assert third_uuid not in uuids
     assert sample_song.uuid in uuids
     # cleanup
     await test_client.request(
         "DELETE",
-        "/v1/library/bulk",
+        LIBRARY_BULK,
         json={"song_ids": [sample_song.uuid]},
         cookies=cookies,
     )
@@ -289,13 +290,13 @@ async def test_bulk_remove_empty_list_returns_400(
 ):
     cookies = await login(test_client, regular_user)
     resp = await test_client.request(
-        "DELETE", "/v1/library/bulk", json={"song_ids": []}, cookies=cookies
+        "DELETE", LIBRARY_BULK, json={"song_ids": []}, cookies=cookies
     )
     assert resp.status_code == 400
 
 
 async def test_bulk_remove_requires_auth(test_client: AsyncClient, sample_song):
     resp = await test_client.request(
-        "DELETE", "/v1/library/bulk", json={"song_ids": [sample_song.uuid]}
+        "DELETE", LIBRARY_BULK, json={"song_ids": [sample_song.uuid]}
     )
     assert resp.status_code == 401

--- a/tests/integration/test_library.py
+++ b/tests/integration/test_library.py
@@ -1,6 +1,16 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import AUTH_LOGIN, LIBRARY, LIBRARY_BULK, LIBRARY_OFFLINE, LIBRARY_PUBLISH, library_offline_path, library_position_path, library_song_path, song_path
+from songbirdapi.routes import (
+    AUTH_LOGIN,
+    LIBRARY,
+    LIBRARY_BULK,
+    LIBRARY_OFFLINE,
+    LIBRARY_PUBLISH,
+    library_offline_path,
+    library_position_path,
+    library_song_path,
+    song_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -57,7 +67,9 @@ async def test_library_contains_added_song(
 async def test_remove_from_library(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
-    resp = await test_client.delete(library_song_path(sample_song.uuid), cookies=cookies)
+    resp = await test_client.delete(
+        library_song_path(sample_song.uuid), cookies=cookies
+    )
     assert resp.status_code == 204
     resp = await test_client.get(LIBRARY, cookies=cookies)
     assert not any(e["song_id"] == sample_song.uuid for e in resp.json())
@@ -79,7 +91,9 @@ async def test_remove_from_library_cleans_offline(
 
 async def test_remove_nonexistent_returns_404(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.delete(library_song_path("does-not-exist"), cookies=cookies)
+    resp = await test_client.delete(
+        library_song_path("does-not-exist"), cookies=cookies
+    )
     assert resp.status_code == 404
 
 

--- a/tests/integration/test_player.py
+++ b/tests/integration/test_player.py
@@ -212,3 +212,17 @@ async def test_put_player_state_malformed_queue_source(
         cookies=cookies,
     )
     assert resp.status_code == 422
+
+
+async def test_player_state_returns_updated_at(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    await test_client.put(
+        "/v1/player/state",
+        json={"shuffle": False, "repeat": "off", "queue": [], "queue_index": -1},
+        cookies=cookies,
+    )
+    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "updated_at" in body
+    assert body["updated_at"] is not None

--- a/tests/integration/test_player.py
+++ b/tests/integration/test_player.py
@@ -1,6 +1,6 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import AUTH_LOGIN, PLAYER_STATE
+from songbirdapi.routes import AUTH_LOGIN, PLAYER_STATE, PLAYER_QUEUE, PLAYER_QUEUE_REORDER, player_queue_song_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -227,3 +227,281 @@ async def test_player_state_returns_updated_at(test_client: AsyncClient, regular
     body = resp.json()
     assert "updated_at" in body
     assert body["updated_at"] is not None
+
+
+# --- Queue mutation endpoints ---
+
+
+async def _seed_queue(test_client, cookies, queue, shuffle=False, shuffle_order=None):
+    await test_client.put(
+        PLAYER_STATE,
+        json={
+            "shuffle": shuffle,
+            "repeat": "off",
+            "queue": queue,
+            "queue_index": 0,
+            "shuffle_order": shuffle_order,
+            "shuffle_seed": 42 if shuffle else None,
+            "shuffle_position": 0,
+        },
+        cookies=cookies,
+    )
+
+
+async def test_queue_insert_appends_to_end(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(test_client, cookies, [sample_song.uuid])
+
+    resp = await test_client.post(
+        PLAYER_QUEUE,
+        json={"song_id": second_song.uuid},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue"] == [sample_song.uuid, second_song.uuid]
+
+
+async def test_queue_insert_at_position(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(test_client, cookies, [sample_song.uuid])
+
+    resp = await test_client.post(
+        PLAYER_QUEUE,
+        json={"song_id": second_song.uuid, "position": 0},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue"] == [second_song.uuid, sample_song.uuid]
+    assert body["queue_index"] == 1
+
+
+async def test_queue_insert_duplicate_is_noop(
+    test_client: AsyncClient, regular_user, sample_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(test_client, cookies, [sample_song.uuid])
+
+    resp = await test_client.post(
+        PLAYER_QUEUE,
+        json={"song_id": sample_song.uuid},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue"] == [sample_song.uuid]
+
+
+async def test_queue_insert_with_source(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(test_client, cookies, [sample_song.uuid])
+
+    source = {"id": "library", "label": "Library", "href": "/library"}
+    resp = await test_client.post(
+        PLAYER_QUEUE,
+        json={"song_id": second_song.uuid, "source": source},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue_sources"][second_song.uuid] == source
+
+
+async def test_queue_insert_updates_shuffle_order(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(
+        test_client, cookies, [sample_song.uuid],
+        shuffle=True, shuffle_order=[0],
+    )
+
+    resp = await test_client.post(
+        PLAYER_QUEUE,
+        json={"song_id": second_song.uuid},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["shuffle_order"]) == 2
+    assert set(body["shuffle_order"]) == {0, 1}
+
+
+async def test_queue_insert_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.post(
+        PLAYER_QUEUE,
+        json={"song_id": sample_song.uuid},
+    )
+    assert resp.status_code == 401
+
+
+async def test_queue_remove_song(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(test_client, cookies, [sample_song.uuid, second_song.uuid])
+
+    resp = await test_client.delete(
+        player_queue_song_path(second_song.uuid),
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue"] == [sample_song.uuid]
+
+
+async def test_queue_remove_adjusts_index(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await test_client.put(
+        PLAYER_STATE,
+        json={
+            "shuffle": False, "repeat": "off",
+            "queue": [sample_song.uuid, second_song.uuid],
+            "queue_index": 1,
+        },
+        cookies=cookies,
+    )
+
+    resp = await test_client.delete(
+        player_queue_song_path(sample_song.uuid),
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue"] == [second_song.uuid]
+    assert body["queue_index"] == 0
+
+
+async def test_queue_remove_missing_song_is_noop(
+    test_client: AsyncClient, regular_user, sample_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(test_client, cookies, [sample_song.uuid])
+
+    resp = await test_client.delete(
+        player_queue_song_path("nonexistent-uuid"),
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue"] == [sample_song.uuid]
+
+
+async def test_queue_remove_cleans_manual_next_and_sources(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    source = {"id": "library", "label": "Library", "href": "/library"}
+    await test_client.put(
+        PLAYER_STATE,
+        json={
+            "shuffle": False, "repeat": "off",
+            "queue": [sample_song.uuid, second_song.uuid],
+            "queue_index": 0,
+            "manual_next": [second_song.uuid],
+            "queue_sources": {second_song.uuid: source},
+        },
+        cookies=cookies,
+    )
+
+    resp = await test_client.delete(
+        player_queue_song_path(second_song.uuid),
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert second_song.uuid not in body["manual_next"]
+    assert second_song.uuid not in body["queue_sources"]
+
+
+async def test_queue_remove_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.delete(
+        player_queue_song_path(sample_song.uuid),
+    )
+    assert resp.status_code == 401
+
+
+async def test_queue_reorder_shuffle_off(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(test_client, cookies, [sample_song.uuid, second_song.uuid])
+
+    resp = await test_client.put(
+        PLAYER_QUEUE_REORDER,
+        json={"from_position": 1, "to_position": 0},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue"] == [second_song.uuid, sample_song.uuid]
+
+
+async def test_queue_reorder_updates_current_index(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(test_client, cookies, [sample_song.uuid, second_song.uuid])
+
+    resp = await test_client.put(
+        PLAYER_QUEUE_REORDER,
+        json={"from_position": 0, "to_position": 2},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue"] == [second_song.uuid, sample_song.uuid]
+    assert body["queue_index"] == 1
+
+
+async def test_queue_reorder_shuffle_on(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(
+        test_client, cookies, [sample_song.uuid, second_song.uuid],
+        shuffle=True, shuffle_order=[0, 1],
+    )
+
+    resp = await test_client.put(
+        PLAYER_QUEUE_REORDER,
+        json={"from_position": 1, "to_position": 0},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["shuffle_order"] == [1, 0]
+    assert body["queue"] == [sample_song.uuid, second_song.uuid]
+
+
+async def test_queue_reorder_noop_same_position(
+    test_client: AsyncClient, regular_user, sample_song, second_song
+):
+    cookies = await login(test_client, regular_user)
+    await _seed_queue(test_client, cookies, [sample_song.uuid, second_song.uuid])
+
+    resp = await test_client.put(
+        PLAYER_QUEUE_REORDER,
+        json={"from_position": 0, "to_position": 0},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queue"] == [sample_song.uuid, second_song.uuid]
+
+
+async def test_queue_reorder_requires_auth(test_client: AsyncClient):
+    resp = await test_client.put(
+        PLAYER_QUEUE_REORDER,
+        json={"from_position": 0, "to_position": 1},
+    )
+    assert resp.status_code == 401

--- a/tests/integration/test_player.py
+++ b/tests/integration/test_player.py
@@ -1,19 +1,20 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, PLAYER_STATE
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
 
 async def test_get_player_state(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    resp = await test_client.get(PLAYER_STATE, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "shuffle" in body
@@ -25,7 +26,7 @@ async def test_get_player_state(test_client: AsyncClient, regular_user):
 async def test_put_player_state(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={"shuffle": True, "repeat": "all", "queue": [], "queue_index": -1},
         cookies=cookies,
     )
@@ -35,11 +36,11 @@ async def test_put_player_state(test_client: AsyncClient, regular_user):
 async def test_player_state_persists(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={"shuffle": True, "repeat": "all", "queue": [], "queue_index": -1},
         cookies=cookies,
     )
-    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    resp = await test_client.get(PLAYER_STATE, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert body["shuffle"] is True
@@ -47,13 +48,13 @@ async def test_player_state_persists(test_client: AsyncClient, regular_user):
 
 
 async def test_get_player_state_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/player/state")
+    resp = await test_client.get(PLAYER_STATE)
     assert resp.status_code == 401
 
 
 async def test_put_player_state_requires_auth(test_client: AsyncClient):
     resp = await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={"shuffle": False, "repeat": "off", "queue": [], "queue_index": -1},
     )
     assert resp.status_code == 401
@@ -62,7 +63,7 @@ async def test_put_player_state_requires_auth(test_client: AsyncClient):
 async def test_put_player_state_invalid_repeat(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={
             "shuffle": False,
             "repeat": "invalid_value",
@@ -79,7 +80,7 @@ async def test_put_player_state_with_queue(
 ):
     cookies = await login(test_client, regular_user)
     resp = await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={
             "shuffle": False,
             "repeat": "one",
@@ -108,7 +109,7 @@ async def test_put_player_state_with_queue_sources(
         }
     }
     resp = await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={
             "shuffle": False,
             "repeat": "off",
@@ -121,7 +122,7 @@ async def test_put_player_state_with_queue_sources(
     assert resp.status_code in (200, 204)
 
     # GET and verify queue_sources
-    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    resp = await test_client.get(PLAYER_STATE, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert body["queue_sources"] == queue_sources
@@ -133,14 +134,14 @@ async def test_put_player_state_without_queue_sources_legacy(
     """PUT without queue_sources (legacy clients) should not error, default to {}."""
     cookies = await login(test_client, regular_user)
     resp = await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={"shuffle": False, "repeat": "off", "queue": [], "queue_index": -1},
         cookies=cookies,
     )
     assert resp.status_code in (200, 204)
 
     # GET and verify queue_sources defaults to {}
-    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    resp = await test_client.get(PLAYER_STATE, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert body["queue_sources"] == {}
@@ -162,7 +163,7 @@ async def test_queue_sources_roundtrip_with_uuid(
 
     # PUT
     resp = await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={
             "shuffle": False,
             "repeat": "all",
@@ -175,14 +176,14 @@ async def test_queue_sources_roundtrip_with_uuid(
     assert resp.status_code in (200, 204)
 
     # First GET
-    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    resp = await test_client.get(PLAYER_STATE, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert source_uuid in body["queue_sources"]
     assert body["queue_sources"][source_uuid] == queue_sources[source_uuid]
 
     # Second GET to verify persistence
-    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    resp = await test_client.get(PLAYER_STATE, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert body["queue_sources"] == queue_sources
@@ -201,7 +202,7 @@ async def test_put_player_state_malformed_queue_source(
         }
     }
     resp = await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={
             "shuffle": False,
             "repeat": "off",
@@ -217,11 +218,11 @@ async def test_put_player_state_malformed_queue_source(
 async def test_player_state_returns_updated_at(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     await test_client.put(
-        "/v1/player/state",
+        PLAYER_STATE,
         json={"shuffle": False, "repeat": "off", "queue": [], "queue_index": -1},
         cookies=cookies,
     )
-    resp = await test_client.get("/v1/player/state", cookies=cookies)
+    resp = await test_client.get(PLAYER_STATE, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "updated_at" in body

--- a/tests/integration/test_player.py
+++ b/tests/integration/test_player.py
@@ -1,6 +1,12 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import AUTH_LOGIN, PLAYER_STATE, PLAYER_QUEUE, PLAYER_QUEUE_REORDER, player_queue_song_path
+from songbirdapi.routes import (
+    AUTH_LOGIN,
+    PLAYER_STATE,
+    PLAYER_QUEUE,
+    PLAYER_QUEUE_REORDER,
+    player_queue_song_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -319,8 +325,11 @@ async def test_queue_insert_updates_shuffle_order(
 ):
     cookies = await login(test_client, regular_user)
     await _seed_queue(
-        test_client, cookies, [sample_song.uuid],
-        shuffle=True, shuffle_order=[0],
+        test_client,
+        cookies,
+        [sample_song.uuid],
+        shuffle=True,
+        shuffle_order=[0],
     )
 
     resp = await test_client.post(
@@ -364,7 +373,8 @@ async def test_queue_remove_adjusts_index(
     await test_client.put(
         PLAYER_STATE,
         json={
-            "shuffle": False, "repeat": "off",
+            "shuffle": False,
+            "repeat": "off",
             "queue": [sample_song.uuid, second_song.uuid],
             "queue_index": 1,
         },
@@ -404,7 +414,8 @@ async def test_queue_remove_cleans_manual_next_and_sources(
     await test_client.put(
         PLAYER_STATE,
         json={
-            "shuffle": False, "repeat": "off",
+            "shuffle": False,
+            "repeat": "off",
             "queue": [sample_song.uuid, second_song.uuid],
             "queue_index": 0,
             "manual_next": [second_song.uuid],
@@ -468,8 +479,11 @@ async def test_queue_reorder_shuffle_on(
 ):
     cookies = await login(test_client, regular_user)
     await _seed_queue(
-        test_client, cookies, [sample_song.uuid, second_song.uuid],
-        shuffle=True, shuffle_order=[0, 1],
+        test_client,
+        cookies,
+        [sample_song.uuid, second_song.uuid],
+        shuffle=True,
+        shuffle_order=[0, 1],
     )
 
     resp = await test_client.put(

--- a/tests/integration/test_playlists.py
+++ b/tests/integration/test_playlists.py
@@ -1,6 +1,15 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import AUTH_LOGIN, PLAYLISTS, library_song_path, playlist_path, playlist_song_path, playlist_songs_bulk_path, playlist_songs_path, song_path
+from songbirdapi.routes import (
+    AUTH_LOGIN,
+    PLAYLISTS,
+    library_song_path,
+    playlist_path,
+    playlist_song_path,
+    playlist_songs_bulk_path,
+    playlist_songs_path,
+    song_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -50,14 +59,12 @@ async def test_create_playlist(test_client: AsyncClient, regular_user):
     assert "id" in body
     assert body["song_count"] == 0
     # cleanup
-    await test_client.delete(playlist_path(body['id']), cookies=cookies)
+    await test_client.delete(playlist_path(body["id"]), cookies=cookies)
 
 
 async def test_create_playlist_appears_in_list(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    create = await test_client.post(
-        PLAYLISTS, json={"name": "listme"}, cookies=cookies
-    )
+    create = await test_client.post(PLAYLISTS, json={"name": "listme"}, cookies=cookies)
     pl_id = create.json()["id"]
     resp = await test_client.get(PLAYLISTS, cookies=cookies)
     assert resp.status_code == 200

--- a/tests/integration/test_playlists.py
+++ b/tests/integration/test_playlists.py
@@ -1,12 +1,13 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, PLAYLISTS, library_song_path, playlist_path, playlist_song_path, playlist_songs_bulk_path, playlist_songs_path, song_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
@@ -17,12 +18,12 @@ async def login(test_client: AsyncClient, user) -> dict:
 
 
 async def test_list_playlists_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/playlists")
+    resp = await test_client.get(PLAYLISTS)
     assert resp.status_code == 401
 
 
 async def test_create_playlist_requires_auth(test_client: AsyncClient):
-    resp = await test_client.post("/v1/playlists", json={"name": "unauth"})
+    resp = await test_client.post(PLAYLISTS, json={"name": "unauth"})
     assert resp.status_code == 401
 
 
@@ -33,7 +34,7 @@ async def test_create_playlist_requires_auth(test_client: AsyncClient):
 
 async def test_list_playlists_empty(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/playlists", cookies=cookies)
+    resp = await test_client.get(PLAYLISTS, cookies=cookies)
     assert resp.status_code == 200
     assert resp.json() == []
 
@@ -41,7 +42,7 @@ async def test_list_playlists_empty(test_client: AsyncClient, regular_user):
 async def test_create_playlist(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        "/v1/playlists", json={"name": "my playlist"}, cookies=cookies
+        PLAYLISTS, json={"name": "my playlist"}, cookies=cookies
     )
     assert resp.status_code == 201
     body = resp.json()
@@ -49,53 +50,53 @@ async def test_create_playlist(test_client: AsyncClient, regular_user):
     assert "id" in body
     assert body["song_count"] == 0
     # cleanup
-    await test_client.delete(f"/v1/playlists/{body['id']}", cookies=cookies)
+    await test_client.delete(playlist_path(body['id']), cookies=cookies)
 
 
 async def test_create_playlist_appears_in_list(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "listme"}, cookies=cookies
+        PLAYLISTS, json={"name": "listme"}, cookies=cookies
     )
     pl_id = create.json()["id"]
-    resp = await test_client.get("/v1/playlists", cookies=cookies)
+    resp = await test_client.get(PLAYLISTS, cookies=cookies)
     assert resp.status_code == 200
     assert any(p["id"] == pl_id for p in resp.json())
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 async def test_rename_playlist(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "old name"}, cookies=cookies
+        PLAYLISTS, json={"name": "old name"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     resp = await test_client.patch(
-        f"/v1/playlists/{pl_id}", json={"name": "new name"}, cookies=cookies
+        playlist_path(pl_id), json={"name": "new name"}, cookies=cookies
     )
     assert resp.status_code == 200
     assert resp.json()["name"] == "new name"
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 async def test_delete_playlist(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "to delete"}, cookies=cookies
+        PLAYLISTS, json={"name": "to delete"}, cookies=cookies
     )
     pl_id = create.json()["id"]
-    resp = await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    resp = await test_client.delete(playlist_path(pl_id), cookies=cookies)
     assert resp.status_code == 204
-    listing = await test_client.get("/v1/playlists", cookies=cookies)
+    listing = await test_client.get(PLAYLISTS, cookies=cookies)
     assert not any(p["id"] == pl_id for p in listing.json())
 
 
 async def test_delete_nonexistent_playlist(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.delete(
-        "/v1/playlists/fake-id-does-not-exist", cookies=cookies
+        playlist_path("fake-id-does-not-exist"), cookies=cookies
     )
     assert resp.status_code == 404
 
@@ -106,15 +107,15 @@ async def test_cannot_access_other_users_playlist(
     reg_cookies = await login(test_client, regular_user)
     adm_cookies = await login(test_client, admin_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "private"}, cookies=reg_cookies
+        PLAYLISTS, json={"name": "private"}, cookies=reg_cookies
     )
     pl_id = create.json()["id"]
     resp = await test_client.patch(
-        f"/v1/playlists/{pl_id}", json={"name": "hacked"}, cookies=adm_cookies
+        playlist_path(pl_id), json={"name": "hacked"}, cookies=adm_cookies
     )
     assert resp.status_code == 404
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=reg_cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=reg_cookies)
 
 
 # ---------------------------------------------------------------------------
@@ -127,74 +128,74 @@ async def test_add_song_to_playlist(
 ):
     cookies = await login(test_client, regular_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "with song"}, cookies=cookies
+        PLAYLISTS, json={"name": "with song"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     resp = await test_client.post(
-        f"/v1/playlists/{pl_id}/songs",
+        playlist_songs_path(pl_id),
         json={"song_uuid": sample_song.uuid},
         cookies=cookies,
     )
     assert resp.status_code == 204
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 async def test_get_playlist_songs(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "songs list"}, cookies=cookies
+        PLAYLISTS, json={"name": "songs list"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     await test_client.post(
-        f"/v1/playlists/{pl_id}/songs",
+        playlist_songs_path(pl_id),
         json={"song_uuid": sample_song.uuid},
         cookies=cookies,
     )
-    resp = await test_client.get(f"/v1/playlists/{pl_id}/songs", cookies=cookies)
+    resp = await test_client.get(playlist_songs_path(pl_id), cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert isinstance(body, list)
     assert any(s["uuid"] == sample_song.uuid for s in body)
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 async def test_add_duplicate_song(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "dupe test"}, cookies=cookies
+        PLAYLISTS, json={"name": "dupe test"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     await test_client.post(
-        f"/v1/playlists/{pl_id}/songs",
+        playlist_songs_path(pl_id),
         json={"song_uuid": sample_song.uuid},
         cookies=cookies,
     )
     resp = await test_client.post(
-        f"/v1/playlists/{pl_id}/songs",
+        playlist_songs_path(pl_id),
         json={"song_uuid": sample_song.uuid},
         cookies=cookies,
     )
     assert resp.status_code == 409
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 async def test_add_nonexistent_song(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "bad song"}, cookies=cookies
+        PLAYLISTS, json={"name": "bad song"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     resp = await test_client.post(
-        f"/v1/playlists/{pl_id}/songs",
+        playlist_songs_path(pl_id),
         json={"song_uuid": "00000000-0000-0000-0000-000000000000"},
         cookies=cookies,
     )
     assert resp.status_code == 404
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 async def test_remove_song_from_playlist(
@@ -202,22 +203,22 @@ async def test_remove_song_from_playlist(
 ):
     cookies = await login(test_client, regular_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "remove song"}, cookies=cookies
+        PLAYLISTS, json={"name": "remove song"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     await test_client.post(
-        f"/v1/playlists/{pl_id}/songs",
+        playlist_songs_path(pl_id),
         json={"song_uuid": sample_song.uuid},
         cookies=cookies,
     )
     resp = await test_client.delete(
-        f"/v1/playlists/{pl_id}/songs/{sample_song.uuid}", cookies=cookies
+        playlist_song_path(pl_id, sample_song.uuid), cookies=cookies
     )
     assert resp.status_code == 204
-    songs = await test_client.get(f"/v1/playlists/{pl_id}/songs", cookies=cookies)
+    songs = await test_client.get(playlist_songs_path(pl_id), cookies=cookies)
     assert songs.json() == []
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 async def test_reorder_playlist(test_client: AsyncClient, regular_user, sample_song):
@@ -227,24 +228,24 @@ async def test_reorder_playlist(test_client: AsyncClient, regular_user, sample_s
     # create a second song via the songs endpoint isn't available here, so we
     # reorder with a single-element list to verify the endpoint is wired correctly
     create = await test_client.post(
-        "/v1/playlists", json={"name": "reorder"}, cookies=cookies
+        PLAYLISTS, json={"name": "reorder"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     await test_client.post(
-        f"/v1/playlists/{pl_id}/songs",
+        playlist_songs_path(pl_id),
         json={"song_uuid": sample_song.uuid},
         cookies=cookies,
     )
     resp = await test_client.patch(
-        f"/v1/playlists/{pl_id}/songs",
+        playlist_songs_path(pl_id),
         json={"song_uuids": [sample_song.uuid]},
         cookies=cookies,
     )
     assert resp.status_code == 204
-    songs = await test_client.get(f"/v1/playlists/{pl_id}/songs", cookies=cookies)
+    songs = await test_client.get(playlist_songs_path(pl_id), cookies=cookies)
     assert songs.json()[0]["uuid"] == sample_song.uuid
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 # ---------------------------------------------------------------------------
@@ -271,24 +272,24 @@ async def test_bulk_add_songs_to_playlist(
         )
         await _crud.insert_song(db, song2)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "bulk add"}, cookies=cookies
+        PLAYLISTS, json={"name": "bulk add"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     # add both songs to library first
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    await test_client.post(f"/v1/library/{second_uuid}", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    await test_client.post(library_song_path(second_uuid), cookies=cookies)
     resp = await test_client.post(
-        f"/v1/playlists/{pl_id}/songs/bulk",
+        playlist_songs_bulk_path(pl_id),
         json={"song_uuids": [sample_song.uuid, second_uuid]},
         cookies=cookies,
     )
     assert resp.status_code == 204
-    songs = await test_client.get(f"/v1/playlists/{pl_id}/songs", cookies=cookies)
+    songs = await test_client.get(playlist_songs_path(pl_id), cookies=cookies)
     uuids = [s["uuid"] for s in songs.json()]
     assert sample_song.uuid in uuids
     assert second_uuid in uuids
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
     async with _TestingSession() as db:
         await _crud.delete_song(db, second_uuid)
 
@@ -297,53 +298,53 @@ async def test_bulk_add_skips_duplicates(
     test_client: AsyncClient, regular_user, sample_song
 ):
     cookies = await login(test_client, regular_user)
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "bulk dedup"}, cookies=cookies
+        PLAYLISTS, json={"name": "bulk dedup"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     # add same song twice in one bulk call
     resp = await test_client.post(
-        f"/v1/playlists/{pl_id}/songs/bulk",
+        playlist_songs_bulk_path(pl_id),
         json={"song_uuids": [sample_song.uuid, sample_song.uuid]},
         cookies=cookies,
     )
     assert resp.status_code == 204
-    songs = await test_client.get(f"/v1/playlists/{pl_id}/songs", cookies=cookies)
+    songs = await test_client.get(playlist_songs_path(pl_id), cookies=cookies)
     uuids = [s["uuid"] for s in songs.json()]
     assert uuids.count(sample_song.uuid) == 1
     # add same song again via a second bulk call — should still be once
     resp2 = await test_client.post(
-        f"/v1/playlists/{pl_id}/songs/bulk",
+        playlist_songs_bulk_path(pl_id),
         json={"song_uuids": [sample_song.uuid]},
         cookies=cookies,
     )
     assert resp2.status_code == 204
-    songs2 = await test_client.get(f"/v1/playlists/{pl_id}/songs", cookies=cookies)
+    songs2 = await test_client.get(playlist_songs_path(pl_id), cookies=cookies)
     assert [s["uuid"] for s in songs2.json()].count(sample_song.uuid) == 1
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 async def test_bulk_add_empty_list_returns_400(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "bulk empty"}, cookies=cookies
+        PLAYLISTS, json={"name": "bulk empty"}, cookies=cookies
     )
     pl_id = create.json()["id"]
     resp = await test_client.post(
-        f"/v1/playlists/{pl_id}/songs/bulk",
+        playlist_songs_bulk_path(pl_id),
         json={"song_uuids": []},
         cookies=cookies,
     )
     assert resp.status_code == 400
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=cookies)
 
 
 async def test_bulk_add_requires_auth(test_client: AsyncClient, sample_song):
     resp = await test_client.post(
-        "/v1/playlists/fake-playlist-id/songs/bulk",
+        playlist_songs_bulk_path("fake-playlist-id"),
         json={"song_uuids": [sample_song.uuid]},
     )
     assert resp.status_code == 401
@@ -355,14 +356,14 @@ async def test_bulk_add_wrong_user_returns_403(
     reg_cookies = await login(test_client, regular_user)
     adm_cookies = await login(test_client, admin_user)
     create = await test_client.post(
-        "/v1/playlists", json={"name": "owner only"}, cookies=reg_cookies
+        PLAYLISTS, json={"name": "owner only"}, cookies=reg_cookies
     )
     pl_id = create.json()["id"]
     resp = await test_client.post(
-        f"/v1/playlists/{pl_id}/songs/bulk",
+        playlist_songs_bulk_path(pl_id),
         json={"song_uuids": [sample_song.uuid]},
         cookies=adm_cookies,
     )
     assert resp.status_code == 403
     # cleanup
-    await test_client.delete(f"/v1/playlists/{pl_id}", cookies=reg_cookies)
+    await test_client.delete(playlist_path(pl_id), cookies=reg_cookies)

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -22,6 +22,7 @@ import pytest
 from httpx import AsyncClient
 
 from songbirdapi import database
+from songbirdapi.routes import AUTH_LOGIN, HEALTH, LIBRARY, library_song_path, song_artwork_path, song_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -32,7 +33,7 @@ def _checkedout() -> int:
 
 async def _login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
@@ -45,7 +46,7 @@ async def test_read_endpoint_releases_connection_after_response(
     cookies = await _login(test_client, regular_user)
     baseline = _checkedout()
     for _ in range(50):
-        resp = await test_client.get("/v1/library", cookies=cookies)
+        resp = await test_client.get(LIBRARY, cookies=cookies)
         assert resp.status_code == 200
     # Allow one in-flight settle — the test client's own request is in
     # flight when this line runs the next time, but with no in-flight
@@ -65,10 +66,10 @@ async def test_write_endpoint_releases_connection_after_response(
     baseline = _checkedout()
     for _ in range(20):
         # Add then remove — idempotent loop, doesn't leak rows.
-        r1 = await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
+        r1 = await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
         assert r1.status_code == 201
         r2 = await test_client.delete(
-            f"/v1/library/{sample_song.uuid}", cookies=cookies
+            library_song_path(sample_song.uuid), cookies=cookies
         )
         assert r2.status_code == 204
     await asyncio.sleep(0.05)
@@ -84,7 +85,7 @@ async def test_endpoint_raising_404_releases_connection(
     cookies = await _login(test_client, regular_user)
     baseline = _checkedout()
     for _ in range(50):
-        resp = await test_client.get("/v1/songs/does-not-exist-xyz", cookies=cookies)
+        resp = await test_client.get(song_path("does-not-exist-xyz"), cookies=cookies)
         assert resp.status_code == 404
     await asyncio.sleep(0.05)
     assert _checkedout() == baseline
@@ -100,7 +101,7 @@ async def test_concurrent_burst_does_not_exhaust_pool(
     baseline = _checkedout()
 
     async def one():
-        r = await test_client.get("/v1/library", cookies=cookies)
+        r = await test_client.get(LIBRARY, cookies=cookies)
         assert r.status_code == 200
 
     await asyncio.gather(*(one() for _ in range(50)))
@@ -122,7 +123,7 @@ async def test_streaming_artwork_releases_session_before_stream(
     # 404 is fine — handler still goes through session_scope read path
     for _ in range(30):
         resp = await test_client.get(
-            f"/v1/songs/{sample_song.uuid}/artwork/full", cookies=cookies
+            song_artwork_path(sample_song.uuid, "full"), cookies=cookies
         )
         assert resp.status_code == 404
     await asyncio.sleep(0.05)
@@ -144,7 +145,7 @@ async def test_health_endpoint_releases_db_session(test_client: AsyncClient):
     few seconds drains the pool over hours. Verify by hammering it."""
     baseline = _checkedout()
     for _ in range(100):
-        resp = await test_client.get("/v1/health")
+        resp = await test_client.get(HEALTH)
         assert resp.status_code == 200
     await asyncio.sleep(0.05)
     assert _checkedout() == baseline

--- a/tests/integration/test_pool.py
+++ b/tests/integration/test_pool.py
@@ -22,7 +22,14 @@ import pytest
 from httpx import AsyncClient
 
 from songbirdapi import database
-from songbirdapi.routes import AUTH_LOGIN, HEALTH, LIBRARY, library_song_path, song_artwork_path, song_path
+from songbirdapi.routes import (
+    AUTH_LOGIN,
+    HEALTH,
+    LIBRARY,
+    library_song_path,
+    song_artwork_path,
+    song_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -66,7 +73,9 @@ async def test_write_endpoint_releases_connection_after_response(
     baseline = _checkedout()
     for _ in range(20):
         # Add then remove — idempotent loop, doesn't leak rows.
-        r1 = await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+        r1 = await test_client.post(
+            library_song_path(sample_song.uuid), cookies=cookies
+        )
         assert r1.status_code == 201
         r2 = await test_client.delete(
             library_song_path(sample_song.uuid), cookies=cookies

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -1,5 +1,6 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, PROPERTIES, PROPERTIES_ITUNES, properties_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -21,7 +22,7 @@ _VALID_PROPERTIES = {
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
@@ -29,7 +30,7 @@ async def login(test_client: AsyncClient, user) -> dict:
 async def test_search_properties(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.get(
-        "/v1/properties", params={"query": "test"}, cookies=cookies
+        PROPERTIES, params={"query": "test"}, cookies=cookies
     )
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
@@ -42,7 +43,7 @@ async def test_search_properties(test_client: AsyncClient, regular_user):
 async def test_put_properties(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     resp = await test_client.put(
-        "/v1/properties",
+        PROPERTIES,
         json={"song_id": sample_song.uuid, "properties": _VALID_PROPERTIES},
         cookies=cookies,
     )
@@ -56,13 +57,13 @@ async def test_put_properties(test_client: AsyncClient, regular_user, sample_son
 
 
 async def test_search_properties_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/properties", params={"query": "test"})
+    resp = await test_client.get(PROPERTIES, params={"query": "test"})
     assert resp.status_code == 401
 
 
 async def test_put_properties_requires_auth(test_client: AsyncClient, sample_song):
     resp = await test_client.put(
-        "/v1/properties",
+        PROPERTIES,
         json={"song_id": sample_song.uuid, "properties": _VALID_PROPERTIES},
     )
     assert resp.status_code == 401
@@ -76,7 +77,7 @@ async def test_put_properties_requires_auth(test_client: AsyncClient, sample_son
 async def test_get_properties_by_id_not_found(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.get(
-        "/v1/properties/00000000-0000-0000-0000-000000000000", cookies=cookies
+        properties_path("00000000-0000-0000-0000-000000000000"), cookies=cookies
     )
     assert resp.status_code == 404
 
@@ -88,7 +89,7 @@ async def test_get_properties_by_id_no_properties(
     # so this verifies the song exists but we test a fresh song with no props
     cookies = await login(test_client, regular_user)
     # Use sample_song after properties have been set; properties exist now so expect 200
-    resp = await test_client.get(f"/v1/properties/{sample_song.uuid}", cookies=cookies)
+    resp = await test_client.get(properties_path(sample_song.uuid), cookies=cookies)
     # Could be 200 (if properties were set by earlier test) or 404 (if not set)
     assert resp.status_code in (200, 404)
 
@@ -96,7 +97,7 @@ async def test_get_properties_by_id_no_properties(
 async def test_get_properties_by_id_requires_auth(
     test_client: AsyncClient, sample_song
 ):
-    resp = await test_client.get(f"/v1/properties/{sample_song.uuid}")
+    resp = await test_client.get(properties_path(sample_song.uuid))
     assert resp.status_code == 401
 
 
@@ -108,7 +109,7 @@ async def test_get_properties_by_id_requires_auth(
 async def test_put_properties_song_not_found(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.put(
-        "/v1/properties",
+        PROPERTIES,
         json={
             "song_id": "00000000-0000-0000-0000-000000000000",
             "properties": _VALID_PROPERTIES,
@@ -124,14 +125,14 @@ async def test_put_properties_song_not_found(test_client: AsyncClient, regular_u
 
 
 async def test_get_itunes_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/properties/itunes", params={"query": "test"})
+    resp = await test_client.get(PROPERTIES_ITUNES, params={"query": "test"})
     assert resp.status_code == 401
 
 
 async def test_get_itunes_returns_list(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.get(
-        "/v1/properties/itunes", params={"query": "test song"}, cookies=cookies
+        PROPERTIES_ITUNES, params={"query": "test song"}, cookies=cookies
     )
     # itunes API may or may not be reachable in test env; accept 200 or 5xx
     assert resp.status_code in (200, 500, 502, 503)

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -1,6 +1,11 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import AUTH_LOGIN, PROPERTIES, PROPERTIES_ITUNES, properties_path
+from songbirdapi.routes import (
+    AUTH_LOGIN,
+    PROPERTIES,
+    PROPERTIES_ITUNES,
+    properties_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -29,9 +34,7 @@ async def login(test_client: AsyncClient, user) -> dict:
 
 async def test_search_properties(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get(
-        PROPERTIES, params={"query": "test"}, cookies=cookies
-    )
+    resp = await test_client.get(PROPERTIES, params={"query": "test"}, cookies=cookies)
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
 

--- a/tests/integration/test_share.py
+++ b/tests/integration/test_share.py
@@ -1,6 +1,13 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import AUTH_LOGIN, download_path, share_download_path, share_info_path, share_song_path, song_path
+from songbirdapi.routes import (
+    AUTH_LOGIN,
+    download_path,
+    share_download_path,
+    share_info_path,
+    share_song_path,
+    song_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -14,9 +21,7 @@ async def login(test_client: AsyncClient, user) -> dict:
 
 async def test_create_share_link(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.post(
-        share_song_path(sample_song.uuid), cookies=cookies
-    )
+    resp = await test_client.post(share_song_path(sample_song.uuid), cookies=cookies)
     assert resp.status_code in (200, 201)
     body = resp.json()
     assert "token" in body

--- a/tests/integration/test_share.py
+++ b/tests/integration/test_share.py
@@ -1,12 +1,13 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, download_path, share_download_path, share_info_path, share_song_path, song_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
@@ -14,7 +15,7 @@ async def login(test_client: AsyncClient, user) -> dict:
 async def test_create_share_link(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        f"/v1/share/songs/{sample_song.uuid}", cookies=cookies
+        share_song_path(sample_song.uuid), cookies=cookies
     )
     assert resp.status_code in (200, 201)
     body = resp.json()
@@ -24,11 +25,11 @@ async def test_create_share_link(test_client: AsyncClient, regular_user, sample_
 async def test_share_info_no_auth(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
     create_resp = await test_client.post(
-        f"/v1/share/songs/{sample_song.uuid}", cookies=cookies
+        share_song_path(sample_song.uuid), cookies=cookies
     )
     token = create_resp.json()["token"]
 
-    resp = await test_client.get(f"/v1/share/{token}/info")
+    resp = await test_client.get(share_info_path(token))
     assert resp.status_code == 200
     body = resp.json()
     assert "song_id" in body
@@ -39,17 +40,17 @@ async def test_create_share_link_nonexistent_song(
     test_client: AsyncClient, regular_user
 ):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.post("/v1/share/songs/nonexistent", cookies=cookies)
+    resp = await test_client.post(share_song_path("nonexistent"), cookies=cookies)
     assert resp.status_code == 404
 
 
 async def test_share_info_bad_token(test_client: AsyncClient):
-    resp = await test_client.get("/v1/share/badtoken/info")
+    resp = await test_client.get(share_info_path("badtoken"))
     assert resp.status_code == 404
 
 
 async def test_create_share_requires_auth(test_client: AsyncClient, sample_song):
-    resp = await test_client.post(f"/v1/share/songs/{sample_song.uuid}")
+    resp = await test_client.post(share_song_path(sample_song.uuid))
     assert resp.status_code == 401
 
 
@@ -59,7 +60,7 @@ async def test_create_share_requires_auth(test_client: AsyncClient, sample_song)
 
 
 async def test_download_shared_bad_token(test_client: AsyncClient):
-    resp = await test_client.get("/v1/share/badtoken/download")
+    resp = await test_client.get(share_download_path("badtoken"))
     assert resp.status_code == 404
 
 
@@ -69,11 +70,11 @@ async def test_download_shared_no_file(
     # sample_song.file_path is /tmp/test-song.mp3 which doesn't actually exist on disk
     cookies = await login(test_client, regular_user)
     create_resp = await test_client.post(
-        f"/v1/share/songs/{sample_song.uuid}", cookies=cookies
+        share_song_path(sample_song.uuid), cookies=cookies
     )
     assert create_resp.status_code in (200, 201)
     token = create_resp.json()["token"]
 
-    resp = await test_client.get(f"/v1/share/{token}/download")
+    resp = await test_client.get(share_download_path(token))
     # file doesn't exist on disk — expect 404
     assert resp.status_code == 404

--- a/tests/integration/test_songs.py
+++ b/tests/integration/test_songs.py
@@ -1,6 +1,15 @@
 import pytest
 from httpx import AsyncClient
-from songbirdapi.routes import AUTH_LOGIN, SONGS, SONGS_LIBRARY, library_song_path, song_artwork_path, song_path, song_play_path, songs_explore_path
+from songbirdapi.routes import (
+    AUTH_LOGIN,
+    SONGS,
+    SONGS_LIBRARY,
+    library_song_path,
+    song_artwork_path,
+    song_path,
+    song_play_path,
+    songs_explore_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 

--- a/tests/integration/test_songs.py
+++ b/tests/integration/test_songs.py
@@ -1,24 +1,25 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import AUTH_LOGIN, SONGS, SONGS_LIBRARY, library_song_path, song_artwork_path, song_path, song_play_path, songs_explore_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
 async def login(test_client: AsyncClient, user) -> dict:
     resp = await test_client.post(
-        "/v1/auth/login", json={"username": user.username, "password": "testpass123"}
+        AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
 
 
 async def test_list_songs_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/songs/")
+    resp = await test_client.get(SONGS)
     assert resp.status_code == 401
 
 
 async def test_list_songs(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/songs/", cookies=cookies)
+    resp = await test_client.get(SONGS, cookies=cookies)
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
 
@@ -27,8 +28,8 @@ async def test_library_songs_contains_uuid(
     test_client: AsyncClient, regular_user, sample_song
 ):
     cookies = await login(test_client, regular_user)
-    await test_client.post(f"/v1/library/{sample_song.uuid}", cookies=cookies)
-    resp = await test_client.get("/v1/songs/library", cookies=cookies)
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    resp = await test_client.get(SONGS_LIBRARY, cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert isinstance(body, list)
@@ -37,13 +38,13 @@ async def test_library_songs_contains_uuid(
 
 async def test_record_play(test_client: AsyncClient, regular_user, sample_song):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.post(f"/v1/songs/{sample_song.uuid}/play", cookies=cookies)
+    resp = await test_client.post(song_play_path(sample_song.uuid), cookies=cookies)
     assert resp.status_code in (200, 204)
 
 
 async def test_explore_week(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/songs/explore?window=week", cookies=cookies)
+    resp = await test_client.get(songs_explore_path("week"), cookies=cookies)
     assert resp.status_code == 200
     body = resp.json()
     assert "most_played" in body
@@ -52,23 +53,23 @@ async def test_explore_week(test_client: AsyncClient, regular_user):
 
 async def test_explore_day(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/songs/explore?window=day", cookies=cookies)
+    resp = await test_client.get(songs_explore_path("day"), cookies=cookies)
     assert resp.status_code == 200
 
 
 async def test_explore_all(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.get("/v1/songs/explore?window=all", cookies=cookies)
+    resp = await test_client.get(songs_explore_path("all"), cookies=cookies)
     assert resp.status_code == 200
 
 
 async def test_explore_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/songs/explore?window=week")
+    resp = await test_client.get(songs_explore_path("week"))
     assert resp.status_code == 401
 
 
 async def test_record_play_requires_auth(test_client: AsyncClient, sample_song):
-    resp = await test_client.post(f"/v1/songs/{sample_song.uuid}/play")
+    resp = await test_client.post(song_play_path(sample_song.uuid))
     assert resp.status_code == 401
 
 
@@ -79,14 +80,14 @@ async def test_record_play_requires_auth(test_client: AsyncClient, sample_song):
 
 async def test_get_artwork_not_found_song(test_client: AsyncClient):
     resp = await test_client.get(
-        "/v1/songs/00000000-0000-0000-0000-000000000000/artwork/full"
+        song_artwork_path("00000000-0000-0000-0000-000000000000", "full")
     )
     assert resp.status_code == 404
 
 
 async def test_get_artwork_no_cached_artwork(test_client: AsyncClient, sample_song):
     # sample_song has no artwork cached
-    resp = await test_client.get(f"/v1/songs/{sample_song.uuid}/artwork/full")
+    resp = await test_client.get(song_artwork_path(sample_song.uuid, "full"))
     assert resp.status_code == 404
 
 
@@ -97,7 +98,7 @@ async def test_get_artwork_no_cached_artwork(test_client: AsyncClient, sample_so
 
 async def test_upload_artwork_requires_auth(test_client: AsyncClient, sample_song):
     resp = await test_client.post(
-        f"/v1/songs/{sample_song.uuid}/artwork",
+        song_artwork_path(sample_song.uuid),
         files={"file": ("art.jpg", b"\xff\xd8\xff\xe0" + b"\x00" * 100, "image/jpeg")},
     )
     assert resp.status_code == 401
@@ -106,7 +107,7 @@ async def test_upload_artwork_requires_auth(test_client: AsyncClient, sample_son
 async def test_upload_artwork_song_not_found(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        "/v1/songs/00000000-0000-0000-0000-000000000000/artwork",
+        song_artwork_path("00000000-0000-0000-0000-000000000000"),
         files={"file": ("art.jpg", b"\xff\xd8\xff\xe0" + b"\x00" * 100, "image/jpeg")},
         cookies=cookies,
     )
@@ -118,7 +119,7 @@ async def test_upload_artwork_invalid_file(
 ):
     cookies = await login(test_client, regular_user)
     resp = await test_client.post(
-        f"/v1/songs/{sample_song.uuid}/artwork",
+        song_artwork_path(sample_song.uuid),
         files={"file": ("art.txt", b"not an image", "text/plain")},
         cookies=cookies,
     )

--- a/tests/integration/test_version.py
+++ b/tests/integration/test_version.py
@@ -1,11 +1,12 @@
 import pytest
 from httpx import AsyncClient
+from songbirdapi.routes import HEALTH, VERSION
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
 async def test_version_no_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/version")
+    resp = await test_client.get(VERSION)
     assert resp.status_code == 200
     body = resp.json()
     assert "api_version" in body
@@ -13,6 +14,6 @@ async def test_version_no_auth(test_client: AsyncClient):
 
 
 async def test_health_no_auth(test_client: AsyncClient):
-    resp = await test_client.get("/v1/health")
+    resp = await test_client.get(HEALTH)
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}

--- a/uv.lock
+++ b/uv.lock
@@ -1741,7 +1741,7 @@ wheels = [
 
 [[package]]
 name = "songbirdapi"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1741,7 +1741,7 @@ wheels = [
 
 [[package]]
 name = "songbirdapi"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Delete `user_offline_songs` when removing songs from library (single + bulk)
- Return `updated_at` in `GET/PUT /player/state` response for cross-device sync detection
- Integration tests for both changes

## Test plan
- [x] `test_remove_from_library_cleans_offline` — single removal cleans offline record
- [x] `test_bulk_remove_cleans_offline` — bulk removal cleans offline records
- [x] `test_player_state_returns_updated_at` — GET response includes `updated_at` after PUT
- [x] All 151 integration tests pass locally