### PR TITLE
feat: admin server-side search, pagination, edit-job usernames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.12"
+version = "0.0.13"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/routers/admin.py
+++ b/songbirdapi/routers/admin.py
@@ -235,7 +235,9 @@ class AdminStats(BaseModel):
     disk_bytes: int
     disk_total: int
     disk_free: int
+    edit_job_count: int
     failed_job_count: int
+    error_log_count: int
     active_share_tokens: int
     import_count: int
     import_failed_count: int
@@ -254,12 +256,18 @@ async def get_stats(db: AsyncSession = Depends(get_db)):
     user_count = (await db.execute(select(func.count()).select_from(User))).scalar_one()
     disk_usage = shutil.disk_usage(config.downloads_dir)
 
+    edit_job_count = (
+        await db.execute(select(func.count()).select_from(EditJob))
+    ).scalar_one()
     failed_job_count = (
         await db.execute(
             select(func.count())
             .select_from(EditJob)
             .where(EditJob.status == EditJobStatus.failed)
         )
+    ).scalar_one()
+    error_log_count = (
+        await db.execute(select(func.count()).select_from(ErrorLog))
     ).scalar_one()
 
     import_count = (
@@ -411,7 +419,9 @@ async def get_stats(db: AsyncSession = Depends(get_db)):
         disk_bytes=disk_usage.used,
         disk_total=disk_usage.total,
         disk_free=disk_usage.free,
+        edit_job_count=edit_job_count,
         failed_job_count=failed_job_count,
+        error_log_count=error_log_count,
         active_share_tokens=active_share_tokens,
         import_count=import_count,
         import_failed_count=import_failed_count,
@@ -438,6 +448,7 @@ async def get_stats(db: AsyncSession = Depends(get_db)):
 class EditJobsPage(BaseModel):
     total: int
     jobs: List[EditJobSummary]
+    status_counts: dict[str, int] = {}
 
 
 @router.get("/edit-jobs", response_model=EditJobsPage)
@@ -461,12 +472,28 @@ async def get_edit_jobs(
     total = (
         await db.execute(select(func.count()).select_from(base.subquery()))
     ).scalar_one()
+
+    counts_base = select(EditJob.status, func.count())
+    if query:
+        pattern = f"%{query}%"
+        counts_base = counts_base.where(
+            or_(
+                cast(EditJob.status, String).ilike(pattern),
+                EditJob.error.ilike(pattern),
+                EditJob.user_id.ilike(pattern),
+                EditJob.id.ilike(pattern),
+            )
+        )
+    counts_rows = (await db.execute(counts_base.group_by(EditJob.status))).all()
+    status_counts = {row[0].value: row[1] for row in counts_rows}
+
     result = await db.execute(
         base.order_by(EditJob.created_at.desc()).offset(offset).limit(limit)
     )
     jobs = list(result.scalars().all())
     return EditJobsPage(
         total=total,
+        status_counts=status_counts,
         jobs=[
             EditJobSummary(
                 job_id=j.id,
@@ -498,6 +525,7 @@ class ErrorLogEntry(BaseModel):
 class ErrorsPage(BaseModel):
     total: int
     errors: List[ErrorLogEntry]
+    source_counts: dict[str, int] = {}
 
 
 @router.get("/errors", response_model=ErrorsPage)
@@ -574,4 +602,9 @@ async def get_errors(
         for j in failed_jobs
     ]
     entries.sort(key=lambda e: e.timestamp, reverse=True)
-    return ErrorsPage(total=total, errors=entries[:limit])
+    source_counts: dict[str, int] = {}
+    if error_log_count > 0:
+        source_counts["error_log"] = error_log_count
+    if failed_job_count_errors > 0:
+        source_counts["failed_edit_job"] = failed_job_count_errors
+    return ErrorsPage(total=total, errors=entries[:limit], source_counts=source_counts)

--- a/songbirdapi/routers/admin.py
+++ b/songbirdapi/routers/admin.py
@@ -200,6 +200,7 @@ class EditJobSummary(BaseModel):
     job_id: str
     source_song_id: str
     user_id: str
+    username: str
     status: str
     result_song_id: Optional[str]
     error: Optional[str]
@@ -374,6 +375,7 @@ async def get_stats(db: AsyncSession = Depends(get_db)):
     # per_user
     users_result = await db.execute(select(User))
     all_users = list(users_result.scalars())
+    all_users_by_id = {u.id: u for u in all_users}
 
     user_song_counts_result = await db.execute(
         select(UserSong.user_id, func.count().label("cnt")).group_by(UserSong.user_id)
@@ -431,6 +433,11 @@ async def get_stats(db: AsyncSession = Depends(get_db)):
                 job_id=j.id,
                 source_song_id=j.source_song_id,
                 user_id=j.user_id,
+                username=(
+                    all_users_by_id[j.user_id].username
+                    if j.user_id in all_users_by_id
+                    else "unknown"
+                ),
                 status=j.status.value,
                 result_song_id=j.result_song_id,
                 error=j.error,
@@ -491,6 +498,11 @@ async def get_edit_jobs(
         base.order_by(EditJob.created_at.desc()).offset(offset).limit(limit)
     )
     jobs = list(result.scalars().all())
+
+    user_ids = {j.user_id for j in jobs}
+    users_result = await db.execute(select(User).where(User.id.in_(user_ids)))
+    users_by_id = {u.id: u for u in users_result.scalars()}
+
     return EditJobsPage(
         total=total,
         status_counts=status_counts,
@@ -499,6 +511,11 @@ async def get_edit_jobs(
                 job_id=j.id,
                 source_song_id=j.source_song_id,
                 user_id=j.user_id,
+                username=(
+                    users_by_id[j.user_id].username
+                    if j.user_id in users_by_id
+                    else "unknown"
+                ),
                 status=j.status.value,
                 result_song_id=j.result_song_id,
                 error=j.error,

--- a/songbirdapi/routers/admin.py
+++ b/songbirdapi/routers/admin.py
@@ -23,7 +23,8 @@ from songbirdapi.models import (
     UserSong,
 )
 from songbirdapi.routers.auth import UserResponse
-from ..dependencies import get_db, load_settings, require_admin
+from songbirdapi.security import verify_password
+from ..dependencies import get_db, get_current_user, load_settings, require_admin
 
 router = APIRouter(
     prefix="/admin", tags=["admin"], dependencies=[Depends(require_admin)]
@@ -33,6 +34,10 @@ router = APIRouter(
 class UpdateUserBody(BaseModel):
     role: Optional[Role] = None
     is_active: Optional[bool] = None
+
+
+class DeleteUserBody(BaseModel):
+    password: str
 
 
 class UsersPage(BaseModel):
@@ -77,12 +82,118 @@ async def update_user(
 
 
 @router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_user(user_id: str, db: AsyncSession = Depends(get_db)):
+async def delete_user(
+    user_id: str,
+    body: DeleteUserBody,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if not await verify_password(body.password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect password"
+        )
     deleted = await crud.delete_user(db, user_id)
     if not deleted:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
+
+
+class AdminImportJobResponse(BaseModel):
+    job_id: str
+    user_id: str
+    username: str
+    status: str
+    song_id: Optional[str] = None
+    track_name: Optional[str] = None
+    error: Optional[str] = None
+    duplicate_of: Optional[str] = None
+    filename: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+class AdminImportJobsPage(BaseModel):
+    total: int
+    jobs: List[AdminImportJobResponse]
+    status_counts: dict[str, int] = {}
+
+
+@router.get("/imports", response_model=AdminImportJobsPage)
+async def list_all_imports(
+    query: str = Query(default=""),
+    limit: int = Query(default=20, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+):
+    base = (
+        select(ImportJob)
+        .outerjoin(Song, ImportJob.song_id == Song.uuid)
+        .outerjoin(User, ImportJob.user_id == User.id)
+    )
+    if query:
+        pattern = f"%{query}%"
+        base = base.where(
+            or_(
+                cast(ImportJob.status, String).ilike(pattern),
+                ImportJob.filename.ilike(pattern),
+                Song.properties["trackName"].astext.ilike(pattern),
+                User.username.ilike(pattern),
+            )
+        )
+
+    total = (
+        await db.execute(select(func.count()).select_from(base.subquery()))
+    ).scalar_one()
+
+    counts_base = select(ImportJob.status, func.count())
+    if query:
+        counts_base = (
+            counts_base.outerjoin(Song, ImportJob.song_id == Song.uuid)
+            .outerjoin(User, ImportJob.user_id == User.id)
+            .where(
+                or_(
+                    cast(ImportJob.status, String).ilike(f"%{query}%"),
+                    ImportJob.filename.ilike(f"%{query}%"),
+                    Song.properties["trackName"].astext.ilike(f"%{query}%"),
+                    User.username.ilike(f"%{query}%"),
+                )
+            )
+        )
+    counts_rows = (await db.execute(counts_base.group_by(ImportJob.status))).all()
+    status_counts = {row[0].value: row[1] for row in counts_rows}
+
+    result = await db.execute(
+        base.order_by(ImportJob.created_at.desc()).offset(offset).limit(limit)
+    )
+    jobs = list(result.scalars().all())
+
+    user_ids = {j.user_id for j in jobs}
+    users_result = await db.execute(select(User).where(User.id.in_(user_ids)))
+    users_by_id = {u.id: u for u in users_result.scalars()}
+
+    responses = []
+    for job in jobs:
+        track_name: str | None = None
+        if job.song_id:
+            song = await crud.get_song(db, job.song_id)
+            if song and song.properties:
+                track_name = song.properties.get("trackName")
+        u = users_by_id.get(job.user_id)
+        responses.append(
+            AdminImportJobResponse(
+                job_id=job.id,
+                user_id=job.user_id,
+                username=u.username if u else "unknown",
+                status=job.status.value,
+                song_id=job.song_id,
+                track_name=track_name,
+                error=job.error,
+                duplicate_of=job.duplicate_of,
+                filename=job.filename,
+                created_at=job.created_at,
+            )
+        )
+    return AdminImportJobsPage(total=total, jobs=responses, status_counts=status_counts)
 
 
 class EditJobSummary(BaseModel):

--- a/songbirdapi/routers/admin.py
+++ b/songbirdapi/routers/admin.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-from sqlalchemy import cast, Date, func, select
+from sqlalchemy import cast, or_, Date, func, select, String
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from songbirdapi import crud
@@ -35,9 +35,33 @@ class UpdateUserBody(BaseModel):
     is_active: Optional[bool] = None
 
 
-@router.get("/users", response_model=List[UserResponse])
-async def list_users(db: AsyncSession = Depends(get_db)):
-    return await crud.list_users(db)
+class UsersPage(BaseModel):
+    total: int
+    users: List[UserResponse]
+
+
+@router.get("/users", response_model=UsersPage)
+async def list_users(
+    query: str = Query(default=""),
+    limit: int = Query(default=20, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+):
+    base = select(User)
+    if query:
+        pattern = f"%{query}%"
+        base = base.where(
+            or_(
+                User.username.ilike(pattern),
+                User.email.ilike(pattern),
+                cast(User.role, String).ilike(pattern),
+            )
+        )
+    total = (
+        await db.execute(select(func.count()).select_from(base.subquery()))
+    ).scalar_one()
+    result = await db.execute(base.order_by(User.username).offset(offset).limit(limit))
+    return UsersPage(total=total, users=list(result.scalars().all()))
 
 
 @router.patch("/users/{user_id}", response_model=UserResponse)
@@ -307,13 +331,27 @@ class EditJobsPage(BaseModel):
 
 @router.get("/edit-jobs", response_model=EditJobsPage)
 async def get_edit_jobs(
+    query: str = Query(default=""),
     limit: int = Query(default=20, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     db: AsyncSession = Depends(get_db),
 ):
-    total = (await db.execute(select(func.count()).select_from(EditJob))).scalar_one()
+    base = select(EditJob)
+    if query:
+        pattern = f"%{query}%"
+        base = base.where(
+            or_(
+                cast(EditJob.status, String).ilike(pattern),
+                EditJob.error.ilike(pattern),
+                EditJob.user_id.ilike(pattern),
+                EditJob.id.ilike(pattern),
+            )
+        )
+    total = (
+        await db.execute(select(func.count()).select_from(base.subquery()))
+    ).scalar_one()
     result = await db.execute(
-        select(EditJob).order_by(EditJob.created_at.desc()).offset(offset).limit(limit)
+        base.order_by(EditJob.created_at.desc()).offset(offset).limit(limit)
     )
     jobs = list(result.scalars().all())
     return EditJobsPage(
@@ -353,33 +391,46 @@ class ErrorsPage(BaseModel):
 
 @router.get("/errors", response_model=ErrorsPage)
 async def get_errors(
+    query: str = Query(default=""),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     db: AsyncSession = Depends(get_db),
 ):
+    error_log_base = select(ErrorLog)
+    failed_job_base = select(EditJob).where(EditJob.status == EditJobStatus.failed)
+    if query:
+        pattern = f"%{query}%"
+        error_log_base = error_log_base.where(
+            or_(
+                ErrorLog.message.ilike(pattern),
+                ErrorLog.path.ilike(pattern),
+                ErrorLog.method.ilike(pattern),
+                cast(ErrorLog.status_code, String).ilike(pattern),
+                ErrorLog.user_id.ilike(pattern),
+            )
+        )
+        failed_job_base = failed_job_base.where(
+            or_(
+                EditJob.error.ilike(pattern),
+                EditJob.user_id.ilike(pattern),
+            )
+        )
+
     error_log_count = (
-        await db.execute(select(func.count()).select_from(ErrorLog))
+        await db.execute(select(func.count()).select_from(error_log_base.subquery()))
     ).scalar_one()
     failed_job_count_errors = (
-        await db.execute(
-            select(func.count())
-            .select_from(EditJob)
-            .where(EditJob.status == EditJobStatus.failed)
-        )
+        await db.execute(select(func.count()).select_from(failed_job_base.subquery()))
     ).scalar_one()
     total = error_log_count + failed_job_count_errors
 
     error_logs_result = await db.execute(
-        select(ErrorLog).order_by(ErrorLog.timestamp.desc()).offset(offset).limit(limit)
+        error_log_base.order_by(ErrorLog.timestamp.desc()).offset(offset).limit(limit)
     )
     error_rows = list(error_logs_result.scalars())
 
     failed_jobs_result = await db.execute(
-        select(EditJob)
-        .where(EditJob.status == EditJobStatus.failed)
-        .order_by(EditJob.created_at.desc())
-        .offset(offset)
-        .limit(limit)
+        failed_job_base.order_by(EditJob.created_at.desc()).offset(offset).limit(limit)
     )
     failed_jobs = list(failed_jobs_result.scalars())
 

--- a/songbirdapi/routers/imports.py
+++ b/songbirdapi/routers/imports.py
@@ -13,7 +13,7 @@ from fastapi import (
     status,
 )
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import cast, func, or_, select, String
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from songbirdcore import itunes
@@ -151,27 +151,51 @@ async def _run_import(
 
 @router.get("")
 async def list_imports(
+    query: str = Query(default=""),
     limit: int = Query(default=20, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> ImportJobsPage:
-    total = (
-        await db.execute(
-            select(func.count())
-            .select_from(ImportJob)
-            .where(ImportJob.user_id == current_user.id)
+    base = (
+        select(ImportJob)
+        .outerjoin(Song, ImportJob.song_id == Song.uuid)
+        .where(ImportJob.user_id == current_user.id)
+    )
+    if query:
+        pattern = f"%{query}%"
+        base = base.where(
+            or_(
+                cast(ImportJob.status, String).ilike(pattern),
+                ImportJob.filename.ilike(pattern),
+                Song.properties["trackName"].astext.ilike(pattern),
+            )
         )
-    ).scalar_one()
-    counts_rows = (
-        await db.execute(
-            select(ImportJob.status, func.count())
-            .where(ImportJob.user_id == current_user.id)
-            .group_by(ImportJob.status)
+
+    count_q = select(func.count()).select_from(base.subquery())
+    total = (await db.execute(count_q)).scalar_one()
+
+    counts_base = (
+        select(ImportJob.status, func.count())
+        .outerjoin(Song, ImportJob.song_id == Song.uuid)
+        .where(ImportJob.user_id == current_user.id)
+    )
+    if query:
+        pattern = f"%{query}%"
+        counts_base = counts_base.where(
+            or_(
+                cast(ImportJob.status, String).ilike(pattern),
+                ImportJob.filename.ilike(pattern),
+                Song.properties["trackName"].astext.ilike(pattern),
+            )
         )
-    ).all()
+    counts_rows = (await db.execute(counts_base.group_by(ImportJob.status))).all()
     status_counts = {row[0].value: row[1] for row in counts_rows}
-    jobs = await crud.list_import_jobs(db, current_user.id, limit=limit, offset=offset)
+
+    result = await db.execute(
+        base.order_by(ImportJob.created_at.desc()).offset(offset).limit(limit)
+    )
+    jobs = list(result.scalars().all())
     responses = []
     for job in jobs:
         track_name: str | None = None

--- a/songbirdapi/routes.py
+++ b/songbirdapi/routes.py
@@ -20,6 +20,7 @@ ADMIN_STATS = f"{V1}/admin/stats"
 ADMIN_ERRORS = f"{V1}/admin/errors"
 ADMIN_EDIT_JOBS = f"{V1}/admin/edit-jobs"
 ADMIN_USERS = f"{V1}/admin/users"
+ADMIN_IMPORTS = f"{V1}/admin/imports"
 
 
 def admin_user_path(user_id: str) -> str:

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.12"
+version = "v0.0.13"

--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -1,16 +1,22 @@
+import uuid
+
 import pytest
 from httpx import AsyncClient
 from songbirdapi.routes import (
     ADMIN_EDIT_JOBS,
     ADMIN_ERRORS,
+    ADMIN_IMPORTS,
     ADMIN_STATS,
     ADMIN_USERS,
     AUTH_LOGIN,
     AUTH_REGISTER,
+    IMPORT,
     admin_user_path,
 )
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+MINIMAL_MP3 = b"ID3\x03\x00\x00\x00\x00\x00\x00" + b"\xff\xfb\x90\x00" + b"\x00" * 413
 
 
 async def login(test_client: AsyncClient, user) -> dict:
@@ -18,6 +24,9 @@ async def login(test_client: AsyncClient, user) -> dict:
         AUTH_LOGIN, json={"username": user.username, "password": "testpass123"}
     )
     return dict(resp.cookies)
+
+
+# ── Stats ──
 
 
 async def test_stats_as_admin(test_client: AsyncClient, admin_user):
@@ -37,6 +46,28 @@ async def test_stats_as_regular_user_forbidden(test_client: AsyncClient, regular
     assert resp.status_code == 403
 
 
+async def test_stats_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get(ADMIN_STATS)
+    assert resp.status_code == 401
+
+
+async def test_stats_has_extended_fields(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(ADMIN_STATS, cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "plays_by_day" in body
+    assert "top_songs" in body
+    assert "per_user" in body
+    assert "disk_total" in body
+    assert "disk_free" in body
+    assert "edit_job_count" in body
+    assert "error_log_count" in body
+
+
+# ── Errors ──
+
+
 async def test_errors_as_admin(test_client: AsyncClient, admin_user):
     cookies = await login(test_client, admin_user)
     resp = await test_client.get(ADMIN_ERRORS, cookies=cookies)
@@ -45,12 +76,87 @@ async def test_errors_as_admin(test_client: AsyncClient, admin_user):
     assert "total" in body
     assert "errors" in body
     assert isinstance(body["errors"], list)
+    assert "source_counts" in body
+    assert isinstance(body["source_counts"], dict)
 
 
 async def test_errors_as_regular_user_forbidden(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
     resp = await test_client.get(ADMIN_ERRORS, cookies=cookies)
     assert resp.status_code == 403
+
+
+async def test_errors_search(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(
+        f"{ADMIN_ERRORS}?query=nonexistent_xyz_12345", cookies=cookies
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["errors"] == []
+
+
+# ── Users ──
+
+
+async def test_list_users_as_admin(test_client: AsyncClient, admin_user, regular_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(ADMIN_USERS, cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total" in body
+    assert "users" in body
+    assert isinstance(body["users"], list)
+    assert body["total"] >= 2
+
+
+async def test_list_users_as_regular_user_forbidden(
+    test_client: AsyncClient, regular_user
+):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get(ADMIN_USERS, cookies=cookies)
+    assert resp.status_code == 403
+
+
+async def test_list_users_pagination(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(f"{ADMIN_USERS}?limit=1&offset=0", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["users"]) <= 1
+    assert body["total"] >= 1
+
+
+async def test_list_users_search(test_client: AsyncClient, admin_user, regular_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(
+        f"{ADMIN_USERS}?query={regular_user.username}", cookies=cookies
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] >= 1
+    assert any(u["username"] == regular_user.username for u in body["users"])
+
+
+async def test_list_users_search_no_results(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(
+        f"{ADMIN_USERS}?query=nonexistent_user_xyz_999", cookies=cookies
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["users"] == []
+
+
+async def test_list_users_search_by_role(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(f"{ADMIN_USERS}?query=admin", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] >= 1
+    assert all(u["role"] == "admin" for u in body["users"])
 
 
 async def test_update_user_as_admin(test_client: AsyncClient, admin_user, regular_user):
@@ -71,23 +177,6 @@ async def test_update_user_as_admin(test_client: AsyncClient, admin_user, regula
     )
     assert restore.status_code == 200
     assert restore.json()["is_active"] is True
-
-
-async def test_list_users_as_admin(test_client: AsyncClient, admin_user, regular_user):
-    cookies = await login(test_client, admin_user)
-    resp = await test_client.get(ADMIN_USERS, cookies=cookies)
-    assert resp.status_code == 200
-    body = resp.json()
-    assert isinstance(body, list)
-    assert len(body) >= 2
-
-
-async def test_list_users_as_regular_user_forbidden(
-    test_client: AsyncClient, regular_user
-):
-    cookies = await login(test_client, regular_user)
-    resp = await test_client.get(ADMIN_USERS, cookies=cookies)
-    assert resp.status_code == 403
 
 
 async def test_update_user_not_found(test_client: AsyncClient, admin_user):
@@ -113,9 +202,7 @@ async def test_update_user_role_as_admin(
     assert resp.json()["role"] == "user"
 
 
-async def test_delete_user_as_admin(test_client: AsyncClient, admin_user):
-    import uuid
-
+async def test_delete_user_requires_password(test_client: AsyncClient, admin_user):
     admin_login = await test_client.post(
         AUTH_LOGIN,
         json={"username": admin_user.username, "password": "testpass123"},
@@ -130,22 +217,62 @@ async def test_delete_user_as_admin(test_client: AsyncClient, admin_user):
     user_id = reg.json()["id"]
 
     cookies = await login(test_client, admin_user)
-    resp = await test_client.delete(admin_user_path(user_id), cookies=cookies)
+    resp = await test_client.request(
+        "DELETE",
+        admin_user_path(user_id),
+        json={"password": "testpass123"},
+        cookies=cookies,
+    )
     assert resp.status_code == 204
+
+
+async def test_delete_user_wrong_password(test_client: AsyncClient, admin_user):
+    admin_login = await test_client.post(
+        AUTH_LOGIN,
+        json={"username": admin_user.username, "password": "testpass123"},
+    )
+    uname = f"todelete_{uuid.uuid4().hex[:6]}"
+    reg = await test_client.post(
+        AUTH_REGISTER,
+        json={"username": uname, "email": f"{uname}@test.com", "password": "pass123"},
+        cookies=admin_login.cookies,
+    )
+    assert reg.status_code == 201
+    user_id = reg.json()["id"]
+
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.request(
+        "DELETE",
+        admin_user_path(user_id),
+        json={"password": "wrongpassword"},
+        cookies=cookies,
+    )
+    assert resp.status_code == 401
 
 
 async def test_delete_user_not_found(test_client: AsyncClient, admin_user):
     cookies = await login(test_client, admin_user)
-    resp = await test_client.delete(
-        admin_user_path("00000000-0000-0000-0000-000000000000"), cookies=cookies
+    resp = await test_client.request(
+        "DELETE",
+        admin_user_path("00000000-0000-0000-0000-000000000000"),
+        json={"password": "testpass123"},
+        cookies=cookies,
     )
     assert resp.status_code == 404
 
 
 async def test_delete_user_requires_admin(test_client: AsyncClient, regular_user):
     cookies = await login(test_client, regular_user)
-    resp = await test_client.delete(admin_user_path("some-id"), cookies=cookies)
+    resp = await test_client.request(
+        "DELETE",
+        admin_user_path("some-id"),
+        json={"password": "testpass123"},
+        cookies=cookies,
+    )
     assert resp.status_code == 403
+
+
+# ── Edit Jobs ──
 
 
 async def test_get_edit_jobs_as_admin(test_client: AsyncClient, admin_user):
@@ -156,6 +283,8 @@ async def test_get_edit_jobs_as_admin(test_client: AsyncClient, admin_user):
     assert "total" in body
     assert "jobs" in body
     assert isinstance(body["jobs"], list)
+    assert "status_counts" in body
+    assert isinstance(body["status_counts"], dict)
 
 
 async def test_get_edit_jobs_requires_admin(test_client: AsyncClient, regular_user):
@@ -169,18 +298,109 @@ async def test_get_edit_jobs_requires_auth(test_client: AsyncClient):
     assert resp.status_code == 401
 
 
-async def test_stats_requires_auth(test_client: AsyncClient):
-    resp = await test_client.get(ADMIN_STATS)
+async def test_get_edit_jobs_search(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(
+        f"{ADMIN_EDIT_JOBS}?query=nonexistent_xyz", cookies=cookies
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["jobs"] == []
+
+
+async def test_get_edit_jobs_pagination(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(f"{ADMIN_EDIT_JOBS}?limit=1&offset=0", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["jobs"]) <= 1
+
+
+# ── Admin Imports ──
+
+
+async def test_admin_imports_as_admin(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(ADMIN_IMPORTS, cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total" in body
+    assert "jobs" in body
+    assert isinstance(body["jobs"], list)
+    assert "status_counts" in body
+    assert isinstance(body["status_counts"], dict)
+
+
+async def test_admin_imports_requires_admin(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get(ADMIN_IMPORTS, cookies=cookies)
+    assert resp.status_code == 403
+
+
+async def test_admin_imports_requires_auth(test_client: AsyncClient):
+    resp = await test_client.get(ADMIN_IMPORTS)
     assert resp.status_code == 401
 
 
-async def test_stats_has_extended_fields(test_client: AsyncClient, admin_user):
-    cookies = await login(test_client, admin_user)
-    resp = await test_client.get(ADMIN_STATS, cookies=cookies)
+async def test_admin_imports_shows_all_users(
+    test_client: AsyncClient, admin_user, regular_user
+):
+    reg_cookies = await login(test_client, regular_user)
+    post = await test_client.post(
+        IMPORT,
+        files={"file": ("admin-test.mp3", MINIMAL_MP3, "audio/mpeg")},
+        cookies=reg_cookies,
+    )
+    assert post.status_code == 202
+
+    adm_cookies = await login(test_client, admin_user)
+    resp = await test_client.get(ADMIN_IMPORTS, cookies=adm_cookies)
     assert resp.status_code == 200
     body = resp.json()
-    assert "plays_by_day" in body
-    assert "top_songs" in body
-    assert "per_user" in body
-    assert "disk_total" in body
-    assert "disk_free" in body
+    assert body["total"] >= 1
+    assert any(j["username"] == regular_user.username for j in body["jobs"])
+
+
+async def test_admin_imports_search(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(
+        f"{ADMIN_IMPORTS}?query=nonexistent_file_xyz", cookies=cookies
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["jobs"] == []
+
+
+async def test_admin_imports_pagination(test_client: AsyncClient, admin_user):
+    cookies = await login(test_client, admin_user)
+    resp = await test_client.get(f"{ADMIN_IMPORTS}?limit=1&offset=0", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["jobs"]) <= 1
+
+
+# ── User Imports (search) ──
+
+
+async def test_user_imports_search(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get(f"{IMPORT}?query=nonexistent_xyz_999", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["jobs"] == []
+
+
+async def test_user_imports_search_by_status(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    await test_client.post(
+        IMPORT,
+        files={"file": ("search-test.mp3", MINIMAL_MP3, "audio/mpeg")},
+        cookies=cookies,
+    )
+    resp = await test_client.get(f"{IMPORT}?query=pending", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert all(j["status"] == "pending" for j in body["jobs"])

--- a/uv.lock
+++ b/uv.lock
@@ -1741,7 +1741,7 @@ wheels = [
 
 [[package]]
 name = "songbirdapi"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Add server-side search + pagination to admin users, edit-jobs, errors, and imports endpoints
- Add `username` field to edit-job responses (replaces opaque user_id on frontend)
- Add `status_counts` to edit-jobs/errors responses, global error stats
- Add admin imports endpoint with password-gated user deletion
- Integration tests for all new admin functionality

## Test plan
- [ ] Admin panel search filters users/jobs/errors correctly
- [ ] Edit jobs table shows username instead of user_id
- [ ] Pagination works across all admin endpoints
- [ ] Password-gated user deletion requires correct admin password