### PR TITLE
feat: editor chain cleanup, restore endpoint, publish fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.13"
+version = "0.0.14"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/crud.py
+++ b/songbirdapi/crud.py
@@ -284,10 +284,13 @@ async def library_ref_count(db: AsyncSession, song_id: str) -> int:
     return result.scalar_one()
 
 
-async def child_ref_count(db: AsyncSession, song_id: str) -> int:
-    result = await db.execute(
-        select(func.count()).where(Song.parent_song_id == song_id)
-    )
+async def child_ref_count(
+    db: AsyncSession, song_id: str, exclude: str | None = None
+) -> int:
+    stmt = select(func.count()).where(Song.parent_song_id == song_id)
+    if exclude:
+        stmt = stmt.where(Song.uuid != exclude)
+    result = await db.execute(stmt)
     return result.scalar_one()
 
 
@@ -297,6 +300,7 @@ async def delete_song(db: AsyncSession, song_id: str) -> None:
     song = await get_song(db, song_id)
     if not song:
         return
+    await db.execute(delete(SongEditDraft).where(SongEditDraft.song_id == song_id))
     await db.execute(delete(Song).where(Song.uuid == song_id))
     await db.commit()
     if song.file_path and os.path.exists(song.file_path):
@@ -736,6 +740,10 @@ async def list_user_drafts(db: AsyncSession, user_id: str) -> list[dict]:
     result = await db.execute(
         select(SongEditDraft, Song)
         .join(Song, SongEditDraft.song_id == Song.uuid)
+        .join(
+            UserSong,
+            (UserSong.song_id == SongEditDraft.song_id) & (UserSong.user_id == user_id),
+        )
         .where(SongEditDraft.user_id == user_id)
         .order_by(SongEditDraft.updated_at.desc())
     )

--- a/songbirdapi/editor.py
+++ b/songbirdapi/editor.py
@@ -1,5 +1,14 @@
 import asyncio
 import json
+import os
+import tempfile
+
+
+def _encode_args(dest_path: str) -> list[str]:
+    ext = os.path.splitext(dest_path)[1].lower()
+    if ext == ".m4a":
+        return ["-c:a", "aac", "-b:a", "256k"]
+    return ["-c:a", "libmp3lame", "-q:a", "0"]
 
 
 async def _get_duration(path: str) -> float:
@@ -98,6 +107,27 @@ def _build_volume_and_fades_filter(
     return f"volume='{expr}':eval=frame"
 
 
+def _is_lossless_eligible(
+    volume: float,
+    fades: list[dict],
+    speed: float,
+    normalize: bool,
+    cuts: list[dict],
+) -> bool:
+    if abs(volume - 1.0) >= 1e-6:
+        return False
+    if abs(speed - 1.0) >= 0.001:
+        return False
+    if normalize:
+        return False
+    if fades:
+        return False
+    for c in cuts:
+        if float(c.get("fade_in") or 0) > 0 or float(c.get("fade_out") or 0) > 0:
+            return False
+    return True
+
+
 async def apply_edits(source_path: str, dest_path: str, params: dict) -> None:
     """Run ffmpeg with trim/volume/fades/cut/speed/normalize params. Raises RuntimeError on failure."""
     trim_start: float = params.get("trim_start") or 0.0
@@ -115,6 +145,15 @@ async def apply_edits(source_path: str, dest_path: str, params: dict) -> None:
         for c in (params.get("cuts") or [])
         if float(c.get("end", 0)) > float(c.get("start", 0))
     ]
+
+    if _is_lossless_eligible(volume, fades, speed, normalize, cuts):
+        if cuts:
+            await _stream_copy_with_cuts(
+                source_path, dest_path, trim_start, trim_end, cuts
+            )
+        else:
+            await _stream_copy_simple(source_path, dest_path, trim_start, trim_end)
+        return
 
     if cuts:
         await _apply_with_cuts(
@@ -139,6 +178,93 @@ async def apply_edits(source_path: str, dest_path: str, params: dict) -> None:
             speed,
             normalize,
         )
+
+
+async def _stream_copy_simple(
+    source_path: str,
+    dest_path: str,
+    trim_start: float,
+    trim_end: float | None,
+) -> None:
+    cmd = ["ffmpeg", "-y"]
+    if trim_start > 0:
+        cmd += ["-ss", str(trim_start)]
+    cmd += ["-i", source_path]
+    if trim_end is not None:
+        cmd += ["-to", str(trim_end - trim_start)]
+    cmd += ["-vn", "-c:a", "copy", dest_path]
+    await _run_ffmpeg(cmd)
+
+
+async def _stream_copy_with_cuts(
+    source_path: str,
+    dest_path: str,
+    trim_start: float,
+    trim_end: float | None,
+    cuts: list[dict],
+) -> None:
+    source_dur = trim_end if trim_end is not None else await _get_duration(source_path)
+    cuts_sorted = sorted(cuts, key=lambda c: float(c["start"]))
+
+    segments: list[tuple[float, float]] = []
+    pos = trim_start
+    for cut in cuts_sorted:
+        cs = max(pos, float(cut["start"]))
+        ce = min(source_dur, float(cut["end"]))
+        if ce <= cs:
+            continue
+        if cs > pos:
+            segments.append((pos, cs))
+        pos = ce
+    if pos < source_dur:
+        segments.append((pos, source_dur))
+
+    if not segments:
+        raise RuntimeError("cuts remove the entire audio segment")
+
+    if len(segments) == 1:
+        s, e = segments[0]
+        await _stream_copy_simple(source_path, dest_path, s, e)
+        return
+
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        seg_files: list[str] = []
+        src_ext = os.path.splitext(source_path)[1] or ".mp3"
+        for i, (s, e) in enumerate(segments):
+            seg_path = os.path.join(tmp_dir, f"seg{i}{src_ext}")
+            await _stream_copy_simple(source_path, seg_path, s, e)
+            seg_files.append(seg_path)
+
+        concat_list = os.path.join(tmp_dir, "concat.txt")
+        with open(concat_list, "w") as f:
+            for p in seg_files:
+                f.write(f"file '{p}'\n")
+
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            concat_list,
+            "-c:a",
+            "copy",
+            dest_path,
+        ]
+        await _run_ffmpeg(cmd)
+    finally:
+        for p in [*seg_files, concat_list]:
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+        try:
+            os.rmdir(tmp_dir)
+        except OSError:
+            pass
 
 
 async def _apply_simple(
@@ -172,7 +298,7 @@ async def _apply_simple(
 
     if filters:
         cmd += ["-af", ",".join(filters)]
-    cmd += ["-vn", "-c:a", "libmp3lame", "-q:a", "0", dest_path]
+    cmd += ["-vn", *_encode_args(dest_path), dest_path]
     await _run_ffmpeg(cmd)
 
 
@@ -270,10 +396,7 @@ async def _apply_with_cuts(
         "-map",
         map_arg,
         "-vn",
-        "-c:a",
-        "libmp3lame",
-        "-q:a",
-        "0",
+        *_encode_args(dest_path),
         dest_path,
     ]
     await _run_ffmpeg(cmd)

--- a/songbirdapi/routers/edit.py
+++ b/songbirdapi/routers/edit.py
@@ -13,7 +13,7 @@ from .. import database
 from ..dependencies import get_current_user, get_db, load_settings
 from ..models import EditJobStatus, Role, Song, User
 from .. import crud
-from ..editor import apply_edits
+from ..editor import apply_edits, _is_lossless_eligible
 from sqlalchemy.ext.asyncio import AsyncSession
 
 _config = load_settings()
@@ -56,6 +56,7 @@ class EditJobResponse(BaseModel):
     status: str
     result_song_id: str | None = None
     error: str | None = None
+    lossless: bool | None = None
 
 
 def _retag_file(file_path: str, merged_props: dict) -> None:
@@ -157,7 +158,8 @@ async def _run_edit_job(
                 )
     else:
         new_uuid = str(_uuid.uuid4())
-        dest_path = os.path.join(_config.downloads_dir, f"{new_uuid}.mp3")
+        ext = os.path.splitext(root_file_path)[1] or ".mp3"
+        dest_path = os.path.join(_config.downloads_dir, f"{new_uuid}{ext}")
         try:
             await apply_edits(root_file_path, dest_path, params)
             final_props = (
@@ -188,15 +190,18 @@ async def _run_edit_job(
                 if source_parent_song_id and source_parent_song_id != root_id:
                     if (
                         await crud.library_ref_count(db, source_parent_song_id) == 0
-                        and await crud.child_ref_count(db, source_parent_song_id) == 0
+                        and await crud.child_ref_count(
+                            db, source_parent_song_id, exclude=source_song_id
+                        )
+                        == 0
                     ):
                         await crud.delete_song(db, source_parent_song_id)
+                        source = await crud.get_song(db, source_song_id)
+                        if source:
+                            source.parent_song_id = root_id
+                            await db.commit()
 
                 await crud.add_to_library(db, user_id, new_uuid)
-                if merged_props is not None and crud._is_publish_eligible(
-                    merged_props, artwork_cached=source_artwork_thumb is not None
-                ):
-                    await crud.publish_song(db, new_uuid, as_original=as_original)
                 await crud.update_edit_job(
                     db, job_id, EditJobStatus.done, result_song_id=new_uuid
                 )
@@ -318,9 +323,26 @@ async def get_edit_job_status(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="job not found"
         )
+    params = job.params or {}
+    lossless = _is_lossless_eligible(
+        volume=params.get("volume") or 1.0,
+        fades=[
+            f
+            for f in (params.get("fades") or [])
+            if float(f.get("end", 0)) > float(f.get("start", 0))
+        ],
+        speed=params.get("speed") or 1.0,
+        normalize=params.get("normalize") or False,
+        cuts=[
+            c
+            for c in (params.get("cuts") or [])
+            if float(c.get("end", 0)) > float(c.get("start", 0))
+        ],
+    )
     return EditJobResponse(
         job_id=job.id,
         status=job.status.value,
         result_song_id=job.result_song_id,
         error=job.error,
+        lossless=lossless,
     )

--- a/songbirdapi/routers/library.py
+++ b/songbirdapi/routers/library.py
@@ -1,13 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..crud import _is_publish_eligible
 from ..database import get_db
 from ..dependencies import get_current_user
-from ..models import Song, User, UserSong
+from ..models import Song, SongEditDraft, User, UserSong
 
 router = APIRouter(prefix="/library", tags=["library"])
 
@@ -115,23 +115,46 @@ async def publish_songs(
 ) -> dict:
     # Only publish songs owned by the current user
     result = await db.execute(
-        select(Song.uuid).where(
+        select(Song).where(
             Song.owner_id == current_user.id, Song.uuid.in_(body.song_ids)
         )
     )
-    ids = [row[0] for row in result.all()]
-    if ids:
-        await db.execute(
-            update(Song)
-            .where(Song.uuid.in_(ids))
-            .values(
-                owner_id=None,
-                source="community",
-                parent_song_id=None,
-                root_song_id=None,
-            )
+    songs = list(result.scalars().all())
+    if not songs:
+        return {"published": 0}
+
+    # Clean up edit chains before publishing
+    for song in songs:
+        if song.parent_song_id and song.root_song_id:
+            cur = song.parent_song_id
+            root = song.root_song_id
+            while cur and cur != root:
+                intermediate = await crud.get_song(db, cur)
+                if not intermediate:
+                    break
+                next_id = intermediate.parent_song_id
+                if (
+                    await crud.library_ref_count(db, cur) == 0
+                    and await crud.child_ref_count(db, cur, exclude=song.uuid) == 0
+                ):
+                    await crud.delete_song(db, cur)
+                cur = next_id
+
+    ids = [s.uuid for s in songs]
+    root_ids = [s.root_song_id for s in songs if s.root_song_id]
+    draft_ids = list(set(ids + root_ids))
+    await db.execute(delete(SongEditDraft).where(SongEditDraft.song_id.in_(draft_ids)))
+    await db.execute(
+        update(Song)
+        .where(Song.uuid.in_(ids))
+        .values(
+            owner_id=None,
+            source="community",
+            parent_song_id=None,
+            root_song_id=None,
         )
-        await db.commit()
+    )
+    await db.commit()
     return {"published": len(ids)}
 
 
@@ -183,6 +206,55 @@ async def remove_from_library(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Not in library"
         )
+
+
+class RestoreRequest(BaseModel):
+    target: str
+
+
+@router.post("/{song_id}/restore", status_code=status.HTTP_204_NO_CONTENT)
+async def restore_song(
+    song_id: str,
+    body: RestoreRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    song = await crud.get_song(db, song_id)
+    if not song or song.owner_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Song not found"
+        )
+    target = await crud.get_song(db, body.target)
+    if not target:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Target not found"
+        )
+
+    await crud.remove_from_library(db, current_user.id, song_id)
+    await crud.add_to_library(db, current_user.id, body.target)
+
+    # Walk from current song up to target, deleting orphaned intermediates
+    cur = song_id
+    while cur and cur != body.target:
+        s = await crud.get_song(db, cur)
+        if not s:
+            break
+        next_id = s.parent_song_id
+        if (
+            await crud.library_ref_count(db, cur) == 0
+            and await crud.child_ref_count(db, cur) == 0
+        ):
+            await crud.delete_song(db, cur)
+        cur = next_id
+
+    # Clean draft on source only — target's draft preserves edit state for the editor
+    await db.execute(
+        delete(SongEditDraft).where(
+            SongEditDraft.user_id == current_user.id,
+            SongEditDraft.song_id == song_id,
+        )
+    )
+    await db.commit()
 
 
 @router.patch("/{song_id}/position", response_model=LibraryEntry)

--- a/songbirdapi/routes.py
+++ b/songbirdapi/routes.py
@@ -46,6 +46,10 @@ def library_offline_path(song_id: str) -> str:
     return f"{LIBRARY}/offline/{song_id}"
 
 
+def library_restore_path(song_id: str) -> str:
+    return f"{LIBRARY}/{song_id}/restore"
+
+
 # Songs
 SONGS = f"{V1}/songs/"
 SONGS_LIBRARY = f"{V1}/songs/library"
@@ -130,6 +134,9 @@ def edit_song_path(song_id: str) -> str:
 
 def edit_draft_path(song_id: str) -> str:
     return f"{V1}/edit/songs/{song_id}/draft"
+
+
+EDIT_DRAFTS = f"{V1}/edit/drafts"
 
 
 def edit_job_path(job_id: str) -> str:

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.13"
+version = "v0.0.14"

--- a/tests/integration/test_edit.py
+++ b/tests/integration/test_edit.py
@@ -226,5 +226,6 @@ async def test_list_user_drafts_requires_library(
     assert resp.status_code == 200
     ids = [d["song_id"] for d in resp.json()]
     assert sample_song.uuid in ids
-    # cleanup draft
+    # cleanup draft + library entry
     await test_client.delete(edit_draft_path(sample_song.uuid), cookies=cookies)
+    await test_client.delete(library_song_path(sample_song.uuid), cookies=cookies)

--- a/tests/integration/test_edit.py
+++ b/tests/integration/test_edit.py
@@ -1,7 +1,10 @@
+import uuid as _uuid
+
 import pytest
 from httpx import AsyncClient
 from songbirdapi.routes import (
     AUTH_LOGIN,
+    EDIT_DRAFTS,
     edit_draft_path,
     edit_job_path,
     edit_song_path,
@@ -94,3 +97,134 @@ async def test_get_edit_job(test_client: AsyncClient, regular_user, sample_song)
     resp = await test_client.get(edit_job_path(job_id), cookies=cookies)
     assert resp.status_code == 200
     assert "status" in resp.json()
+
+
+async def test_edit_job_lossless_field(
+    test_client: AsyncClient, regular_user, sample_song
+):
+    cookies = await login(test_client, regular_user)
+    create_resp = await test_client.post(
+        edit_song_path(sample_song.uuid),
+        json={"params": _EDIT_PARAMS, "overwrite": False},
+        cookies=cookies,
+    )
+    job_id = create_resp.json()["job_id"]
+    resp = await test_client.get(edit_job_path(job_id), cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "lossless" in body
+    # default params (no volume/speed/fade changes) should be lossless-eligible
+    assert body["lossless"] is True
+
+
+# ---------------------------------------------------------------------------
+# crud.child_ref_count with exclude param
+# ---------------------------------------------------------------------------
+
+
+async def test_child_ref_count_exclude(test_client: AsyncClient):
+    from songbirdapi import crud as _crud
+    from songbirdapi.models import Song as _Song
+    from tests.integration.conftest import _TestingSession
+
+    parent_id = str(_uuid.uuid4())
+    child1_id = str(_uuid.uuid4())
+    child2_id = str(_uuid.uuid4())
+    async with _TestingSession() as db:
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=parent_id, url="https://example.com/parent", file_path="/tmp/p.mp3"
+            ),
+        )
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=child1_id,
+                url="https://example.com/c1",
+                file_path="/tmp/c1.mp3",
+                parent_song_id=parent_id,
+            ),
+        )
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=child2_id,
+                url="https://example.com/c2",
+                file_path="/tmp/c2.mp3",
+                parent_song_id=parent_id,
+            ),
+        )
+    async with _TestingSession() as db:
+        assert await _crud.child_ref_count(db, parent_id) == 2
+        assert await _crud.child_ref_count(db, parent_id, exclude=child1_id) == 1
+        assert await _crud.child_ref_count(db, parent_id, exclude=child2_id) == 1
+    # cleanup
+    async with _TestingSession() as db:
+        await _crud.delete_song(db, child2_id)
+        await _crud.delete_song(db, child1_id)
+        await _crud.delete_song(db, parent_id)
+
+
+# ---------------------------------------------------------------------------
+# crud.delete_song cleans up drafts
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_song_cleans_drafts(test_client: AsyncClient, regular_user):
+    from songbirdapi import crud as _crud
+    from songbirdapi.models import Song as _Song
+    from tests.integration.conftest import _TestingSession
+
+    song_id = str(_uuid.uuid4())
+    async with _TestingSession() as db:
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=song_id,
+                url="https://example.com/draft-del",
+                file_path="/tmp/dd.mp3",
+            ),
+        )
+        await _crud.upsert_edit_draft(db, regular_user.id, song_id, _EDIT_PARAMS)
+        draft = await _crud.get_edit_draft(db, regular_user.id, song_id)
+        assert draft is not None
+        await _crud.delete_song(db, song_id)
+        draft = await _crud.get_edit_draft(db, regular_user.id, song_id)
+        assert draft is None
+
+
+# ---------------------------------------------------------------------------
+# crud.list_user_drafts only returns drafts for songs in user's library
+# ---------------------------------------------------------------------------
+
+
+async def test_list_user_drafts_requires_library(
+    test_client: AsyncClient, regular_user, sample_song
+):
+    from songbirdapi import crud as _crud
+    from tests.integration.conftest import _TestingSession
+
+    cookies = await login(test_client, regular_user)
+    # save a draft
+    await test_client.put(
+        edit_draft_path(sample_song.uuid), json=_EDIT_PARAMS, cookies=cookies
+    )
+    # NOT in library -> draft should not appear in list
+    async with _TestingSession() as db:
+        await _crud.remove_from_library(db, regular_user.id, sample_song.uuid)
+    resp = await test_client.get(EDIT_DRAFTS, cookies=cookies)
+    assert resp.status_code == 200
+    ids = [d["song_id"] for d in resp.json()]
+    assert sample_song.uuid not in ids
+
+    # Add to library -> draft should appear
+    from songbirdapi.routes import library_song_path
+
+    await test_client.post(library_song_path(sample_song.uuid), cookies=cookies)
+    resp = await test_client.get(EDIT_DRAFTS, cookies=cookies)
+    assert resp.status_code == 200
+    ids = [d["song_id"] for d in resp.json()]
+    assert sample_song.uuid in ids
+    # cleanup draft
+    await test_client.delete(edit_draft_path(sample_song.uuid), cookies=cookies)

--- a/tests/integration/test_library.py
+++ b/tests/integration/test_library.py
@@ -1,3 +1,5 @@
+import uuid as _uuid
+
 import pytest
 from httpx import AsyncClient
 from songbirdapi.routes import (
@@ -8,6 +10,7 @@ from songbirdapi.routes import (
     LIBRARY_PUBLISH,
     library_offline_path,
     library_position_path,
+    library_restore_path,
     library_song_path,
     song_path,
 )
@@ -312,5 +315,311 @@ async def test_bulk_remove_empty_list_returns_400(
 async def test_bulk_remove_requires_auth(test_client: AsyncClient, sample_song):
     resp = await test_client.request(
         "DELETE", LIBRARY_BULK, json={"song_ids": [sample_song.uuid]}
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Publish chain cleanup
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_nulls_owner_and_sets_community(
+    test_client: AsyncClient, regular_user
+):
+    from songbirdapi import crud as _crud
+    from songbirdapi.models import Song as _Song
+    from tests.integration.conftest import _TestingSession
+
+    cookies = await login(test_client, regular_user)
+    song_id = str(_uuid.uuid4())
+    async with _TestingSession() as db:
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=song_id,
+                url="https://example.com/pub1",
+                file_path="/tmp/pub1.mp3",
+                owner_id=regular_user.id,
+            ),
+        )
+    await test_client.post(library_song_path(song_id), cookies=cookies)
+    resp = await test_client.post(
+        LIBRARY_PUBLISH, json={"song_ids": [song_id]}, cookies=cookies
+    )
+    assert resp.status_code == 200
+    assert resp.json()["published"] == 1
+
+    async with _TestingSession() as db:
+        song = await _crud.get_song(db, song_id)
+        assert song.owner_id is None
+        assert song.source == "community"
+        assert song.parent_song_id is None
+        assert song.root_song_id is None
+    # cleanup
+    async with _TestingSession() as db:
+        await _crud.delete_song(db, song_id)
+
+
+async def test_publish_deletes_orphan_intermediates(
+    test_client: AsyncClient, regular_user
+):
+    from songbirdapi import crud as _crud
+    from songbirdapi.models import Song as _Song
+    from tests.integration.conftest import _TestingSession
+
+    cookies = await login(test_client, regular_user)
+    root_id = str(_uuid.uuid4())
+    mid_id = str(_uuid.uuid4())
+    leaf_id = str(_uuid.uuid4())
+    async with _TestingSession() as db:
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=root_id, url="https://example.com/root", file_path="/tmp/root.mp3"
+            ),
+        )
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=mid_id,
+                url="https://example.com/mid",
+                file_path="/tmp/mid.mp3",
+                parent_song_id=root_id,
+                root_song_id=root_id,
+                owner_id=regular_user.id,
+            ),
+        )
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=leaf_id,
+                url="https://example.com/leaf",
+                file_path="/tmp/leaf.mp3",
+                parent_song_id=mid_id,
+                root_song_id=root_id,
+                owner_id=regular_user.id,
+            ),
+        )
+    await test_client.post(library_song_path(leaf_id), cookies=cookies)
+    resp = await test_client.post(
+        LIBRARY_PUBLISH, json={"song_ids": [leaf_id]}, cookies=cookies
+    )
+    assert resp.status_code == 200
+
+    async with _TestingSession() as db:
+        # mid should be deleted (orphaned intermediate)
+        assert await _crud.get_song(db, mid_id) is None
+        # root still exists
+        assert await _crud.get_song(db, root_id) is not None
+    # cleanup
+    async with _TestingSession() as db:
+        await _crud.delete_song(db, leaf_id)
+        await _crud.delete_song(db, root_id)
+
+
+async def test_publish_deletes_drafts(test_client: AsyncClient, regular_user):
+    from songbirdapi import crud as _crud
+    from songbirdapi.models import Song as _Song
+    from tests.integration.conftest import _TestingSession
+    from songbirdapi.routes import edit_draft_path
+
+    cookies = await login(test_client, regular_user)
+    song_id = str(_uuid.uuid4())
+    async with _TestingSession() as db:
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=song_id,
+                url="https://example.com/pubdraft",
+                file_path="/tmp/pubdraft.mp3",
+                owner_id=regular_user.id,
+            ),
+        )
+    await test_client.post(library_song_path(song_id), cookies=cookies)
+    # save a draft
+    params = {
+        "trim_start": 0,
+        "trim_end": None,
+        "volume": 1.0,
+        "fades": [],
+        "speed": 1.0,
+        "normalize": False,
+        "cuts": [],
+    }
+    await test_client.put(edit_draft_path(song_id), json=params, cookies=cookies)
+    # publish
+    await test_client.post(
+        LIBRARY_PUBLISH, json={"song_ids": [song_id]}, cookies=cookies
+    )
+    # draft should be gone
+    async with _TestingSession() as db:
+        draft = await _crud.get_edit_draft(db, regular_user.id, song_id)
+        assert draft is None
+    # cleanup
+    async with _TestingSession() as db:
+        await _crud.delete_song(db, song_id)
+
+
+# ---------------------------------------------------------------------------
+# Restore endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_restore_swaps_library_entry(test_client: AsyncClient, regular_user):
+    from songbirdapi import crud as _crud
+    from songbirdapi.models import Song as _Song
+    from tests.integration.conftest import _TestingSession
+
+    cookies = await login(test_client, regular_user)
+    root_id = str(_uuid.uuid4())
+    child_id = str(_uuid.uuid4())
+    async with _TestingSession() as db:
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=root_id,
+                url="https://example.com/restore-root",
+                file_path="/tmp/rr.mp3",
+            ),
+        )
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=child_id,
+                url="https://example.com/restore-child",
+                file_path="/tmp/rc.mp3",
+                parent_song_id=root_id,
+                root_song_id=root_id,
+                owner_id=regular_user.id,
+            ),
+        )
+    await test_client.post(library_song_path(child_id), cookies=cookies)
+    resp = await test_client.post(
+        library_restore_path(child_id),
+        json={"target": root_id},
+        cookies=cookies,
+    )
+    assert resp.status_code == 204
+
+    # library should now have root, not child
+    lib = await test_client.get(LIBRARY, cookies=cookies)
+    ids = [e["song_id"] for e in lib.json()]
+    assert root_id in ids
+    assert child_id not in ids
+
+    # child should have been deleted (orphan)
+    async with _TestingSession() as db:
+        assert await _crud.get_song(db, child_id) is None
+    # cleanup
+    await test_client.delete(library_song_path(root_id), cookies=cookies)
+    async with _TestingSession() as db:
+        await _crud.delete_song(db, root_id)
+
+
+async def test_restore_cleans_drafts(test_client: AsyncClient, regular_user):
+    from songbirdapi import crud as _crud
+    from songbirdapi.models import Song as _Song
+    from tests.integration.conftest import _TestingSession
+    from songbirdapi.routes import edit_draft_path
+
+    cookies = await login(test_client, regular_user)
+    root_id = str(_uuid.uuid4())
+    child_id = str(_uuid.uuid4())
+    async with _TestingSession() as db:
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=root_id,
+                url="https://example.com/restore-draft-root",
+                file_path="/tmp/rdr.mp3",
+            ),
+        )
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=child_id,
+                url="https://example.com/restore-draft-child",
+                file_path="/tmp/rdc.mp3",
+                parent_song_id=root_id,
+                root_song_id=root_id,
+                owner_id=regular_user.id,
+            ),
+        )
+    await test_client.post(library_song_path(child_id), cookies=cookies)
+    # save drafts on both
+    params = {
+        "trim_start": 0,
+        "trim_end": None,
+        "volume": 1.0,
+        "fades": [],
+        "speed": 1.0,
+        "normalize": False,
+        "cuts": [],
+    }
+    await test_client.put(edit_draft_path(child_id), json=params, cookies=cookies)
+    # Need root in library temporarily to save a draft on it
+    await test_client.post(library_song_path(root_id), cookies=cookies)
+    await test_client.put(edit_draft_path(root_id), json=params, cookies=cookies)
+    await test_client.delete(library_song_path(root_id), cookies=cookies)
+
+    await test_client.post(
+        library_restore_path(child_id),
+        json={"target": root_id},
+        cookies=cookies,
+    )
+    # source draft gone, target draft preserved (for revert-to-last-save UX)
+    async with _TestingSession() as db:
+        assert await _crud.get_edit_draft(db, regular_user.id, child_id) is None
+        assert await _crud.get_edit_draft(db, regular_user.id, root_id) is not None
+    # cleanup
+    await test_client.delete(library_song_path(root_id), cookies=cookies)
+    async with _TestingSession() as db:
+        await _crud.delete_song(db, root_id)
+
+
+async def test_restore_not_owned_returns_404(test_client: AsyncClient, regular_user):
+    from songbirdapi import crud as _crud
+    from songbirdapi.models import Song as _Song
+    from tests.integration.conftest import _TestingSession
+
+    cookies = await login(test_client, regular_user)
+    song_id = str(_uuid.uuid4())
+    async with _TestingSession() as db:
+        await _crud.insert_song(
+            db,
+            _Song(
+                uuid=song_id,
+                url="https://example.com/restore-notown",
+                file_path="/tmp/rno.mp3",
+            ),
+        )
+    resp = await test_client.post(
+        library_restore_path(song_id),
+        json={"target": song_id},
+        cookies=cookies,
+    )
+    assert resp.status_code == 404
+    # cleanup
+    async with _TestingSession() as db:
+        await _crud.delete_song(db, song_id)
+
+
+async def test_restore_nonexistent_song_returns_404(
+    test_client: AsyncClient, regular_user
+):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.post(
+        library_restore_path("00000000-0000-0000-0000-000000000000"),
+        json={"target": "00000000-0000-0000-0000-000000000001"},
+        cookies=cookies,
+    )
+    assert resp.status_code == 404
+
+
+async def test_restore_requires_auth(test_client: AsyncClient, sample_song):
+    resp = await test_client.post(
+        library_restore_path(sample_song.uuid),
+        json={"target": sample_song.uuid},
     )
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- 2-edit cap fix: `child_ref_count` now accepts `exclude` param to properly delete grandparent intermediates
- `delete_song` cleans up orphaned `SongEditDraft` rows
- `list_user_drafts` joins on `UserSong` to only return drafts for songs in user's library
- Removed auto-publish from non-overwrite saves — publish only via library publish modal
- Publish endpoint walks and deletes intermediate edit chain, cleans drafts on published songs and their roots
- New `POST /library/{song_id}/restore` endpoint for atomic revert/restore with orphan cleanup and draft preservation
- 12 new integration tests covering all new behaviors

## Test plan
- [x] Backend integration tests pass (38/38)
- [x] Manual testing: save → revert to last save → restore original → publish flow verified
- [ ] CI green