### PR TITLE
feat: trigram search for partial matching

### DIFF
--- a/migrations/versions/b3d4e5f6g7h8_add_trigram_search.py
+++ b/migrations/versions/b3d4e5f6g7h8_add_trigram_search.py
@@ -1,0 +1,38 @@
+"""add pg_trgm extension and trigram index for song search
+
+Revision ID: b3d4e5f6g7h8
+Revises: a2c31a799bb0
+Create Date: 2026-05-16 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3d4e5f6g7h8"
+down_revision: Union[str, Sequence[str], None] = "a2c31a799bb0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.execute("""
+        CREATE INDEX idx_songs_trgm_search
+        ON songs
+        USING gin (
+            (
+                COALESCE(properties->>'trackName', '') || ' ' ||
+                COALESCE(properties->>'artistName', '') || ' ' ||
+                COALESCE(properties->>'collectionName', '')
+            )
+            gin_trgm_ops
+        )
+        """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_songs_trgm_search")
+    op.execute("DROP EXTENSION IF EXISTS pg_trgm")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.15"
+version = "0.0.16"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/crud.py
+++ b/songbirdapi/crud.py
@@ -2,7 +2,7 @@ import uuid as _uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from sqlalchemy import delete, func, select, text
+from sqlalchemy import delete, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import (
@@ -109,8 +109,6 @@ async def publish_song(
 
 
 def _owner_filter(user_id: str | None):
-    from sqlalchemy import or_
-
     if user_id:
         return or_(Song.owner_id.is_(None), Song.owner_id == user_id)
     return Song.owner_id.is_(None)
@@ -119,19 +117,20 @@ def _owner_filter(user_id: str | None):
 async def search_songs(
     db: AsyncSession, query: str, user_id: str | None = None, limit: int = 50
 ) -> list[Song]:
+    pattern = f"%{query}%"
+    search_col = (
+        func.coalesce(Song.properties["trackName"].as_string(), "")
+        + " "
+        + func.coalesce(Song.properties["artistName"].as_string(), "")
+        + " "
+        + func.coalesce(Song.properties["collectionName"].as_string(), "")
+    )
     result = await db.execute(
         select(Song)
         .where(
             _owner_filter(user_id),
             Song.parent_song_id.is_(None),
-            func.to_tsvector(
-                "english",
-                func.coalesce(Song.properties["trackName"].as_string(), "")
-                + " "
-                + func.coalesce(Song.properties["artistName"].as_string(), "")
-                + " "
-                + func.coalesce(Song.properties["collectionName"].as_string(), ""),
-            ).op("@@")(func.plainto_tsquery("english", query)),
+            search_col.ilike(pattern),
         )
         .limit(limit)
     )

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.15"
+version = "v0.0.16"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -128,3 +128,30 @@ async def second_song(test_client):
     yield song
     async with _TestingSession() as db:
         await crud.delete_song(db, song.uuid)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def searchable_song(test_client):
+    async with _TestingSession() as db:
+        song = Song(
+            uuid=str(uuid.uuid4()),
+            url="https://example.com/searchable-song",
+            file_path="/tmp/searchable-song.mp3",
+            properties={
+                "trackName": "Billie Jean",
+                "artistName": "Michael Jackson",
+                "collectionName": "Thriller",
+                "artworkUrl100": "https://example.com/art.jpg",
+                "primaryGenreName": "Pop",
+                "trackNumber": 5,
+                "trackCount": 9,
+                "collectionId": "99999",
+                "discNumber": 1,
+                "discCount": 1,
+                "releaseDate": "1982-11-30",
+            },
+        )
+        await crud.insert_song(db, song)
+    yield song
+    async with _TestingSession() as db:
+        await crud.delete_song(db, song.uuid)

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -39,6 +39,61 @@ async def test_search_properties(test_client: AsyncClient, regular_user):
     assert isinstance(resp.json(), list)
 
 
+async def test_search_partial_trackname(
+    test_client: AsyncClient, regular_user, searchable_song
+):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get(PROPERTIES, params={"query": "bill"}, cookies=cookies)
+    assert resp.status_code == 200
+    results = resp.json()
+    uuids = [r["uuid"] for r in results]
+    assert searchable_song.uuid in uuids
+
+
+async def test_search_partial_artist(
+    test_client: AsyncClient, regular_user, searchable_song
+):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get(PROPERTIES, params={"query": "mich"}, cookies=cookies)
+    assert resp.status_code == 200
+    results = resp.json()
+    uuids = [r["uuid"] for r in results]
+    assert searchable_song.uuid in uuids
+
+
+async def test_search_short_prefix(
+    test_client: AsyncClient, regular_user, searchable_song
+):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get(PROPERTIES, params={"query": "billi"}, cookies=cookies)
+    assert resp.status_code == 200
+    results = resp.json()
+    uuids = [r["uuid"] for r in results]
+    assert searchable_song.uuid in uuids
+
+
+async def test_search_case_insensitive(
+    test_client: AsyncClient, regular_user, searchable_song
+):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get(
+        PROPERTIES, params={"query": "BILLIE"}, cookies=cookies
+    )
+    assert resp.status_code == 200
+    results = resp.json()
+    uuids = [r["uuid"] for r in results]
+    assert searchable_song.uuid in uuids
+
+
+async def test_search_no_results(test_client: AsyncClient, regular_user):
+    cookies = await login(test_client, regular_user)
+    resp = await test_client.get(
+        PROPERTIES, params={"query": "zzxxyynomatch"}, cookies=cookies
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
 @pytest.mark.xfail(
     reason="sample_song fixture has fake file_path; source returns 500 when file missing instead of 422/409 (routers/properties.py:175). Needs real-mp3 fixture or graceful error.",
     strict=True,


### PR DESCRIPTION
## Summary
- Replace `plainto_tsquery` FTS with `ILIKE` + `pg_trgm` GIN index
- Enables partial substring matching (typing "bil" finds "Billie Jean")
- Case-insensitive, works from 2+ characters on the frontend
- Migration adds `pg_trgm` extension and trigram index on song properties

## Test plan
- [ ] Integration tests pass (partial trackname, partial artist, short prefix, case-insensitive, no results)
- [ ] Restart local API, type partial names in download search — results appear instantly