### PR TITLE
fix: timestamp defaults and deploy stdin

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,7 +84,7 @@ jobs:
             # the old container running. force-recreate guarantees we get
             # the new image.
             docker-compose pull songbirdapi
-            docker-compose run --rm --entrypoint alembic songbirdapi upgrade head
+            docker-compose run -T --rm --entrypoint alembic songbirdapi upgrade head
             docker-compose up -d --force-recreate songbirdapi
             healthy=
             for i in $(seq 1 30); do

--- a/migrations/versions/db1d80281c83_fix_timestamp_server_defaults_to_use_.py
+++ b/migrations/versions/db1d80281c83_fix_timestamp_server_defaults_to_use_.py
@@ -1,0 +1,39 @@
+"""fix timestamp server defaults to use func.now()
+
+Revision ID: db1d80281c83
+Revises: b3d4e5f6g7h8
+Create Date: 2026-05-18 18:56:47.145044
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "db1d80281c83"
+down_revision: Union[str, Sequence[str], None] = "b3d4e5f6g7h8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column("users", "created_at", server_default=sa.func.now())
+    op.alter_column("songs", "created_at", server_default=sa.func.now())
+    op.alter_column("user_songs", "added_at", server_default=sa.func.now())
+    op.alter_column("song_plays", "played_at", server_default=sa.func.now())
+    op.alter_column("user_player_state", "updated_at", server_default=sa.func.now())
+    op.alter_column("song_downloads", "downloaded_at", server_default=sa.func.now())
+    op.alter_column("song_share_tokens", "created_at", server_default=sa.func.now())
+    op.alter_column("edit_jobs", "created_at", server_default=sa.func.now())
+    op.alter_column("edit_jobs", "updated_at", server_default=sa.func.now())
+    op.alter_column("song_edit_drafts", "updated_at", server_default=sa.func.now())
+    op.alter_column("user_offline_songs", "created_at", server_default=sa.func.now())
+    op.alter_column("error_logs", "timestamp", server_default=sa.func.now())
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.16"
+version = "0.0.17"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/models.py
+++ b/songbirdapi/models.py
@@ -62,7 +62,7 @@ class User(Base):
         Boolean, nullable=False, server_default="true"
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
 
@@ -84,7 +84,7 @@ class Song(Base):
     owner_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     source: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
     __table_args__ = (
@@ -103,7 +103,7 @@ class UserSong(Base):
         Text, ForeignKey("songs.uuid", ondelete="CASCADE"), primary_key=True
     )
     added_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
     last_position: Mapped[float] = mapped_column(
         Float, nullable=False, server_default="0"
@@ -124,7 +124,7 @@ class SongPlay(Base):
         Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
     played_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
     __table_args__ = (
@@ -163,7 +163,7 @@ class UserPlayerState(Base):
         JSONB, nullable=False, server_default="{}"
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
 
@@ -178,7 +178,7 @@ class SongDownload(Base):
         Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
     downloaded_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
     __table_args__ = (
@@ -201,7 +201,7 @@ class SongShareToken(Base):
         DateTime(timezone=True), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
 
@@ -224,10 +224,10 @@ class EditJob(Base):
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
     params: Mapped[dict] = mapped_column(JSONB, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
 
@@ -266,7 +266,7 @@ class SongEditDraft(Base):
     )
     params: Mapped[dict] = mapped_column(JSONB, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
 
@@ -307,7 +307,7 @@ class UserOfflineSong(Base):
         Text, ForeignKey("songs.uuid", ondelete="CASCADE"), primary_key=True
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
 
 
@@ -327,7 +327,7 @@ class ErrorLog(Base):
 
     id: Mapped[str] = mapped_column(Text, primary_key=True)
     timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default="now()"
+        DateTime(timezone=True), server_default=func.now()
     )
     level: Mapped[str] = mapped_column(Text, nullable=False)
     path: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.16"
+version = "v0.0.17"


### PR DESCRIPTION
## Summary
- All `server_default="now()"` (string, evaluated once at migration time) replaced with `server_default=func.now()` (live SQL expression)
- Alembic migration to fix existing column defaults in prod
- Add `-T` to `docker-compose run` in deploy workflow to prevent stdin consumption from SSH heredoc (closes #18)

## Test plan
- [x] Migration runs clean locally
- [x] New song downloads get correct `created_at` timestamps
- [x] Lint + unit tests pass
- [ ] CI passes