### PR TITLE
fix: deploy stdin consumed by docker-compose run

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,7 +84,7 @@ jobs:
             # the old container running. force-recreate guarantees we get
             # the new image.
             docker-compose pull songbirdapi
-            docker-compose run -T --rm --entrypoint alembic songbirdapi upgrade head
+            docker-compose run -T --rm --entrypoint alembic songbirdapi upgrade head </dev/null
             docker-compose up -d --force-recreate songbirdapi
             healthy=
             for i in $(seq 1 30); do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.17"
+version = "0.0.18"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.17"
+version = "v0.0.18"


### PR DESCRIPTION
## Summary
- `-T` alone doesn't prevent `docker-compose run` from reading stdin in a `bash -s` heredoc
- Adding `</dev/null` fully isolates the alembic container from the SSH heredoc stream
- Verified: all deploy steps (pull, alembic, force-recreate, health check) now execute

## Root cause
`docker-compose run` attaches stdin by default. In a `bash -s << 'ENDSSH'` context, this consumes the remaining heredoc content — subsequent commands never execute.

## Test plan
- [x] Reproduced on keebox: without `/dev/null`, steps after alembic are eaten
- [x] With `/dev/null`, all steps execute and health check passes