### PR TITLE
fix: set max_age on auth cookies to persist across browser restarts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "songbirdapi"
 authors = [
     {name = "Christian Boin"},
 ]
-version = "0.0.18"
+version = "0.0.19"
 description = "Music download api"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/songbirdapi/routers/auth.py
+++ b/songbirdapi/routers/auth.py
@@ -9,6 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from songbirdapi import crud
 from songbirdapi.models import Role, User
 from songbirdapi.security import (
+    ACCESS_TOKEN_EXPIRE_MINUTES,
+    REFRESH_TOKEN_EXPIRE_DAYS,
     create_access_token,
     create_refresh_token,
     decode_token,
@@ -46,8 +48,20 @@ class UserResponse(BaseModel):
 
 
 def _set_auth_cookies(response: Response, access_token: str, refresh_token: str):
-    response.set_cookie(ACCESS_COOKIE, access_token, httponly=True, samesite="lax")
-    response.set_cookie(REFRESH_COOKIE, refresh_token, httponly=True, samesite="lax")
+    response.set_cookie(
+        ACCESS_COOKIE,
+        access_token,
+        httponly=True,
+        samesite="lax",
+        max_age=ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    )
+    response.set_cookie(
+        REFRESH_COOKIE,
+        refresh_token,
+        httponly=True,
+        samesite="lax",
+        max_age=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600,
+    )
 
 
 @router.post("/login")
@@ -103,7 +117,13 @@ async def refresh(
         raise credentials_exception
 
     access_token = create_access_token(user.id, user.role.value, config.jwt_secret)
-    response.set_cookie(ACCESS_COOKIE, access_token, httponly=True, samesite="lax")
+    response.set_cookie(
+        ACCESS_COOKIE,
+        access_token,
+        httponly=True,
+        samesite="lax",
+        max_age=ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    )
     return {"message": "token refreshed"}
 
 

--- a/songbirdapi/version.py
+++ b/songbirdapi/version.py
@@ -1,1 +1,1 @@
-version = "v0.0.18"
+version = "v0.0.19"


### PR DESCRIPTION
## Root cause

Auth cookies were set without `max_age`, making them **session cookies**. Session cookies are deleted when the browser restarts or the OS kills the tab (common on mobile). Users were being logged out whenever this happened.

## Changes

- `_set_auth_cookies`: `access_token` max_age = 15 min, `refresh_token` max_age = 7 days (matching JWT expiry)
- `/refresh` endpoint: `access_token` max_age = 15 min

## Test plan
- [x] Login, close browser, reopen — should stay logged in for up to 7 days
- [x] Check browser devtools: cookies should show an expiry date, not "Session"